### PR TITLE
fix(symbolwinbar): Fix highlight

### DIFF
--- a/lua/lspsaga/definition.lua
+++ b/lua/lspsaga/definition.lua
@@ -61,12 +61,8 @@ function def.preview_definition(timeout_ms)
       start_line = range.start.line
     end
 
-    local content = vim.api.nvim_buf_get_lines(
-      bufnr,
-      start_line,
-      range['end'].line + 1 + config.max_preview_lines,
-      false
-    )
+    local content =
+      vim.api.nvim_buf_get_lines(bufnr, start_line, range['end'].line + 1 + config.max_preview_lines, false)
     content = vim.list_extend({ config.definition_preview_icon .. 'Definition Preview: ' .. short_name, '' }, content)
 
     local opts = {

--- a/lua/lspsaga/implement.lua
+++ b/lua/lspsaga/implement.lua
@@ -36,12 +36,8 @@ function implement.lspsaga_implementation(timeout_ms)
       start_line = range.start.line
     end
 
-    local content = vim.api.nvim_buf_get_lines(
-      bufnr,
-      start_line,
-      range['end'].line + 1 + config.max_preview_lines,
-      false
-    )
+    local content =
+      vim.api.nvim_buf_get_lines(bufnr, start_line, range['end'].line + 1 + config.max_preview_lines, false)
     content = vim.list_extend({ config.definition_preview_icon .. 'Lsp Implements', '' }, content)
     local filetype = vim.api.nvim_buf_get_option(bufnr, 'filetype')
 


### PR DESCRIPTION
The current way of highlighting is broken

- The `nvim-web-devicons` function is incorrect and won't work for languages. Ex. haskell

- Highlight colors are shared between splits. If we are using devicons anyway you should let users config from there.