### PR TITLE
Display preview for outgoing calls only if buffer content is available.

### DIFF
--- a/lua/lspsaga/callhierarchy.lua
+++ b/lua/lspsaga/callhierarchy.lua
@@ -528,11 +528,17 @@ function ch:preview()
     { scope = 'local', win = self.preview_winid }
   )
 
-  api.nvim_win_set_cursor(
-    self.preview_winid,
-    { data.range.start.line + 1, data.range.start.character }
-  )
-  vim.bo[data.bufnr].filetype = vim.bo[self.main_buf].filetype
+  -- Check if the cursor position is within the buffer's valid range.
+  local buf_line_count = api.nvim_buf_line_count(data.bufnr)
+  local cursor_line = data.range.start.line + 1
+
+  if cursor_line >= 1 and cursor_line <= buf_line_count then
+    api.nvim_win_set_cursor(
+      self.preview_winid,
+      { data.range.start.line + 1, data.range.start.character }
+    )
+    vim.bo[data.bufnr].filetype = vim.bo[self.main_buf].filetype
+  end
   api.nvim_set_option_value('winbar', '', { scope = 'local', win = self.preview_winid })
 end
 

--- a/lua/lspsaga/callhierarchy.lua
+++ b/lua/lspsaga/callhierarchy.lua
@@ -530,13 +530,11 @@ function ch:preview()
 
   -- Check if the cursor position is within the buffer's valid range.
   local buf_line_count = api.nvim_buf_line_count(data.bufnr)
-  local cursor_line = data.range.start.line + 1
+  local cursor_row = data.range.start.line + 1
+  local cursor_column = data.range.start.character
 
-  if cursor_line >= 1 and cursor_line <= buf_line_count then
-    api.nvim_win_set_cursor(
-      self.preview_winid,
-      { data.range.start.line + 1, data.range.start.character }
-    )
+  if cursor_row >= 1 and cursor_row <= buf_line_count then
+    api.nvim_win_set_cursor(self.preview_winid, { cursor_row, cursor_column })
     vim.bo[data.bufnr].filetype = vim.bo[self.main_buf].filetype
   end
   api.nvim_set_option_value('winbar', '', { scope = 'local', win = self.preview_winid })


### PR DESCRIPTION
## Why?
When executing `:Lspsaga outgoing_calls` for a java method, and when the cursor is positioned on a node that is outside of the project scope, an error occurs since the preview buffer is not being loaded correctly:

>Error executing lua callback: .../nvim/plugged/lspsaga.nvim/lua/lspsaga/callhierarchy.lua:522: Cursor position outside buffer stack traceback:

![before-fix](https://user-images.githubusercontent.com/1727634/232548326-75e5205f-39b2-4e03-a414-5d3f8e042af7.png)

E.g., for `CountDownLatch.class` the node url is:
> jdt://contents/java.base/java.util.concurrent/CountDownLatch.class?=jdt.ls-java-project/%5C/Users%5C/anton%5C/.sdkman%5C/candidates%5C/java%5C/19.0.2-amzn%5C/lib%5C/
jrt-fs.jar%60java.base=/javadoc_location=/https:%5C/%5C/docs.oracle.com%5C/en%5C/java%5C/javase%5C/19%5C/docs%5C/api%5C/=/%3Cjava.util.concurrent(CountDownLatch.class

and its preview cannot be loaded correctly.

As a temporary workaround, we can disable the part for moving the cursor and setting the filetype for a preview buffer with no (or not enough) content.

## What?
Do not attempt to move the cursor or set the filetype for a preview buffer with less content than expected.

## Testing Done
1. Opened a java project.
2. Executed `:Lspsaga outgoing_calls`
3. Navigated to CountDownLatch and observed no error, even though the preview buffer is empty.
4. Navigated to the next node in the project, which preview is displayed correctly.
![after-fix](https://user-images.githubusercontent.com/1727634/232549371-38a236b8-bd01-41ec-a6e7-5845b4d813e3.png)
![after-fix-next-node](https://user-images.githubusercontent.com/1727634/232549388-8087c777-b27f-4822-8caa-517ed5d00eb3.png)

as expected.

## Notes
Provides a temporary workaround for this issue: https://github.com/nvimdev/lspsaga.nvim/issues/975#issuecomment-1510706110