### PR TITLE
#975: Fix JDT previews in "outgoing_calls" popup.

### DIFF
--- a/lua/lspsaga/callhierarchy.lua
+++ b/lua/lspsaga/callhierarchy.lua
@@ -458,9 +458,9 @@ local function load_jdt_preview(bufnr, uri)
   vim.bo[bufnr].filetype = 'java'
 
   vim.wait(config.request_timeout, function()
-    return next(lsp.get_active_clients({ name = 'jdtls', bufnr = bufnr})) ~= nil
+    return next(lsp.get_active_clients({ name = 'jdtls', bufnr = bufnr })) ~= nil
   end)
-  local client = lsp.get_active_clients({ name = 'jdtls', bufnr = bufnr})[1]
+  local client = lsp.get_active_clients({ name = 'jdtls', bufnr = bufnr })[1]
   assert(client, 'Must have a `jdtls` client to load class file or jdt uri')
 
   local content

--- a/lua/lspsaga/callhierarchy.lua
+++ b/lua/lspsaga/callhierarchy.lua
@@ -457,8 +457,7 @@ local function load_jdt_preview(bufnr, uri)
     -- This triggers FileType event which should fire up the lsp client if not already running.
     vim.bo[bufnr].filetype = 'java'
 
-    local timeout_ms = 5000
-    vim.wait(timeout_ms, function()
+    vim.wait(config.request_timeout, function()
       return next(lsp.get_active_clients({ name = "jdtls", bufnr = bufnr})) ~= nil
     end)
     local client = lsp.get_active_clients({ name = "jdtls", bufnr = bufnr})[1]
@@ -479,7 +478,7 @@ local function load_jdt_preview(bufnr, uri)
     client.request("java/classFileContents", params, handler, bufnr)
     -- Need to block. Otherwise logic could run that sets the cursor to a position
     -- that's still missing.
-    vim.wait(timeout_ms, function() return content ~= nil end)
+    vim.wait(config.request_timeout, function() return content ~= nil end)
 end
 
 local function get_preview_data(node)

--- a/lua/lspsaga/callhierarchy.lua
+++ b/lua/lspsaga/callhierarchy.lua
@@ -478,8 +478,8 @@ local function load_jdt_preview(bufnr, uri)
   client.request('java/classFileContents', params, handler, bufnr)
   -- Need to block. Otherwise logic could run that sets the cursor to a position
   -- that's still missing.
-  vim.wait(config.request_timeout, function() 
-    return content ~= nil 
+  vim.wait(config.request_timeout, function()
+    return content ~= nil
   end)
 end
 

--- a/lua/lspsaga/callhierarchy.lua
+++ b/lua/lspsaga/callhierarchy.lua
@@ -458,27 +458,29 @@ local function load_jdt_preview(bufnr, uri)
   vim.bo[bufnr].filetype = 'java'
 
   vim.wait(config.request_timeout, function()
-    return next(lsp.get_active_clients({ name = "jdtls", bufnr = bufnr})) ~= nil
+    return next(lsp.get_active_clients({ name = 'jdtls', bufnr = bufnr})) ~= nil
   end)
-  local client = lsp.get_active_clients({ name = "jdtls", bufnr = bufnr})[1]
+  local client = lsp.get_active_clients({ name = 'jdtls', bufnr = bufnr})[1]
   assert(client, 'Must have a `jdtls` client to load class file or jdt uri')
 
   local content
   local function handler(err, result)
     assert(not err, vim.inspect(err))
     content = result
-    api.nvim_buf_set_lines(bufnr, 0, -1, false, vim.split(result, "\n", { plain = true }))
+    api.nvim_buf_set_lines(bufnr, 0, -1, false, vim.split(result, '\n', { plain = true }))
     vim.bo[bufnr].modifiable = false
   end
 
   local params = {
-    uri = uri
+    uri = uri,
   }
 
-  client.request("java/classFileContents", params, handler, bufnr)
+  client.request('java/classFileContents', params, handler, bufnr)
   -- Need to block. Otherwise logic could run that sets the cursor to a position
   -- that's still missing.
-  vim.wait(config.request_timeout, function() return content ~= nil end)
+  vim.wait(config.request_timeout, function() 
+    return content ~= nil 
+  end)
 end
 
 local function get_preview_data(node)
@@ -490,7 +492,7 @@ local function get_preview_data(node)
   local range = node.target.range
   local bufnr = vim.uri_to_bufnr(uri)
 
-  if string.sub(uri, 1, 4) == "jdt:" then
+  if string.sub(uri, 1, 4) == 'jdt:' then
     load_jdt_preview(bufnr, uri)
   end
 

--- a/lua/lspsaga/callhierarchy.lua
+++ b/lua/lspsaga/callhierarchy.lua
@@ -450,35 +450,35 @@ function ch:get_node_at_cursor()
 end
 
 local function load_jdt_preview(bufnr, uri)
-    vim.bo[bufnr].modifiable = true
-    vim.bo[bufnr].swapfile = false
-    vim.bo[bufnr].buftype = 'nofile'
+  vim.bo[bufnr].modifiable = true
+  vim.bo[bufnr].swapfile = false
+  vim.bo[bufnr].buftype = 'nofile'
 
-    -- This triggers FileType event which should fire up the lsp client if not already running.
-    vim.bo[bufnr].filetype = 'java'
+  -- This triggers FileType event which should fire up the lsp client if not already running.
+  vim.bo[bufnr].filetype = 'java'
 
-    vim.wait(config.request_timeout, function()
-      return next(lsp.get_active_clients({ name = "jdtls", bufnr = bufnr})) ~= nil
-    end)
-    local client = lsp.get_active_clients({ name = "jdtls", bufnr = bufnr})[1]
-    assert(client, 'Must have a `jdtls` client to load class file or jdt uri')
+  vim.wait(config.request_timeout, function()
+    return next(lsp.get_active_clients({ name = "jdtls", bufnr = bufnr})) ~= nil
+  end)
+  local client = lsp.get_active_clients({ name = "jdtls", bufnr = bufnr})[1]
+  assert(client, 'Must have a `jdtls` client to load class file or jdt uri')
 
-    local content
-    local function handler(err, result)
-      assert(not err, vim.inspect(err))
-      content = result
-      api.nvim_buf_set_lines(bufnr, 0, -1, false, vim.split(result, "\n", { plain = true }))
-      vim.bo[bufnr].modifiable = false
-    end
+  local content
+  local function handler(err, result)
+    assert(not err, vim.inspect(err))
+    content = result
+    api.nvim_buf_set_lines(bufnr, 0, -1, false, vim.split(result, "\n", { plain = true }))
+    vim.bo[bufnr].modifiable = false
+  end
 
-    local params = {
-      uri = uri
-    }
+  local params = {
+    uri = uri
+  }
 
-    client.request("java/classFileContents", params, handler, bufnr)
-    -- Need to block. Otherwise logic could run that sets the cursor to a position
-    -- that's still missing.
-    vim.wait(config.request_timeout, function() return content ~= nil end)
+  client.request("java/classFileContents", params, handler, bufnr)
+  -- Need to block. Otherwise logic could run that sets the cursor to a position
+  -- that's still missing.
+  vim.wait(config.request_timeout, function() return content ~= nil end)
 end
 
 local function get_preview_data(node)


### PR DESCRIPTION
## Why?
When executing `:Lspsaga outgoing_calls` for a java method, the preview for `jdt` based nodes (e.g. class files outside of the project) does not currently work. 
![before-fix](https://user-images.githubusercontent.com/1727634/232712923-f5f636be-806c-45e8-9429-bfecd494081c.png)

This PR aims to fix the preview of the files using a JDT LS client.

## What?
Use a JDT LS client to display the node content when previewing a specific node. The implementation is based on `nvim-jdtls/lua/jdtls.lua`'s `function M.open_classfile(fname)` method. Since `open_classfile` opens the file in the current buffer, I had to provide a separate method, which uses an already created buffer.  

Ultimately, the `load_jdt_preview` function should be part of the https://github.com/mfussenegger/nvim-jdtls plugin. Once such a method is available there, we can drop the `load_jdt_preview` method.

## Testing Done
1. Opened a java project.
2. Executed `:Lspsaga outgoing_calls`
3. Navigated to CountDownLatch and observed that the preview of the file is displayed correctly and the respective method (the constructor in this case) is visible in the preview.
![Screenshot 2023-04-18 at 10 58 54](https://user-images.githubusercontent.com/1727634/232713202-66e48ee9-feb1-494d-af75-77f90c227b5a.png)
4. Navigated a few nodes below to the `assertTrue(boolean, String)` entry and made sure the method is visible in the preview window.
 
![Screenshot 2023-04-18 at 10 58 59](https://user-images.githubusercontent.com/1727634/232713438-0af43114-5b1b-4fb7-a33b-015079dafee4.png)

as expected.

## Notes
Fixes https://github.com/nvimdev/lspsaga.nvim/issues/975.