### PR TITLE
Don't map <esc> to quit in renaming unless it's normal mode

### DIFF
--- a/lua/lspsaga/rename.lua
+++ b/lua/lspsaga/rename.lua
@@ -33,9 +33,11 @@ function rename:apply_action_keys()
   local modes = { 'i', 'n', 'v' }
 
   for i, mode in pairs(modes) do
-    vim.keymap.set(mode, config.rename.quit, function()
-      self:close_rename_win()
-    end, { buffer = self.bufnr })
+    if string.lower(config.name.quit) ~= '<esc>' or mode == 'n' then
+      vim.keymap.set(mode, config.rename.quit, function()
+        self:close_rename_win()
+      end, { buffer = self.bufnr })
+    end
 
     if i ~= 3 then
       vim.keymap.set(mode, config.rename.exec, function()


### PR DESCRIPTION
Currently, if the user has `<esc>` mapped to `rename.quit`, they cannot enter normal mode from either insert or visual mode. Instead, pressing `<esc>` closes the window.