### PR TITLE
bad argument #1 to 'sub' (number expected, got nil)

### DIFF
--- a/lua/lspsaga/finder.lua
+++ b/lua/lspsaga/finder.lua
@@ -273,7 +273,7 @@ function finder:create_finder_data(result, method)
       start_col = node.col - 10
     end
     node.word = api.nvim_buf_get_text(node.bufnr, node.row, start_col, node.row, node.ecol, {})[1]
-    if node.word:find('^%s') then
+    if node.word:find('%S') then
       node.word = node.word:sub(node.word:find('%S'), #node.word)
     end
 


### PR DESCRIPTION
I sometimes receive an error: `...site/pack/packer/opt/lspsaga.nvim/lua/lspsaga/finder.lua:277: bad argument #1 to 'sub' (number expected, got nil)`

This seems to fix it