### PR TITLE
fix(rename): due to indexing typo field

### DIFF
--- a/lua/lspsaga/rename.lua
+++ b/lua/lspsaga/rename.lua
@@ -33,7 +33,7 @@ function rename:apply_action_keys()
   local modes = { 'i', 'n', 'v' }
 
   for i, mode in pairs(modes) do
-    if string.lower(config.name.quit) ~= '<esc>' or mode == 'n' then
+    if string.lower(config.rename.quit) ~= '<esc>' or mode == 'n' then
       vim.keymap.set(mode, config.rename.quit, function()
         self:close_rename_win()
       end, { buffer = self.bufnr })


### PR DESCRIPTION

Before this PR:

```lua
Error executing Lua callback: ...te/pack/packer/start/lspsaga.nvim/lua/lspsaga/rename.lua:36: attempt to index field 'name' (a nil value)
stack traceback:
        ...te/pack/packer/start/lspsaga.nvim/lua/lspsaga/rename.lua:36: in function 'apply_action_keys'
        ...te/pack/packer/start/lspsaga.nvim/lua/lspsaga/rename.lua:191: in function 'lsp_rename'
        ...e/pack/packer/start/lspsaga.nvim/lua/lspsaga/command.lua:20: in function <...e/pack/packer/start/lspsaga.nvim/lua/lspsaga/command.lua:19>
        ...e/pack/packer/start/lspsaga.nvim/lua/lspsaga/command.lua:65: in function 'load_command'
        ...m/site/pack/packer/start/lspsaga.nvim/plugin/lspsaga.lua:8: in function <...m/site/pack/packer/start/lspsaga.nvim/plugin/lspsaga.lua:7>
```