### PR TITLE
Fix issue with hover_doc becoming unusable

### DIFF
--- a/lua/lspsaga/hover.lua
+++ b/lua/lspsaga/hover.lua
@@ -230,6 +230,7 @@ function hover:do_request(args)
   local params = util.make_position_params()
   local count, total = support_clients()
   if count == 0 and should_error(args) then
+    self.pending_request = false
     vim.notify('[Lspsaga] all server of buffer not support hover request')
     return
   end


### PR DESCRIPTION
If hover_doc is executed once in a buffer that does not support Hover, hover_doc becomes unusable afterwards.
In this case, the following message is displayed:
```
[Lspsaga] There is already a hover request, please wait for the response.
```

This issue has been fixed.