### PR TITLE
Fix the highlight group assigned to the title icon in the hover doc

### DIFF
--- a/lua/lspsaga/hover.lua
+++ b/lua/lspsaga/hover.lua
@@ -115,7 +115,7 @@ function hover:open_floating_preview(res, option_fn)
 
   if fn.has('nvim-0.9') == 1 and config.ui.title then
     float_option.title = {
-      { config.ui.hover, 'Exception' },
+      { config.ui.hover, 'TitleIcon' },
       { ' Hover', 'TitleString' },
     }
   end


### PR DESCRIPTION
I think the highlight group for the icon in the title of a hover doc is supposed to be TitleIcon and not Exception given the group's name, and the fact that it's only present in the highlights.lua file.