### PR TITLE
Fix project class names in outgoing calls preview.

### DIFF
--- a/lua/lspsaga/callhierarchy.lua
+++ b/lua/lspsaga/callhierarchy.lua
@@ -127,7 +127,6 @@ function ch:call_hierarchy(item, parent)
         local classNamePart = ''
 
         -- Class name resolution for Java
-        -- 
         if vim.bo[api.nvim_get_current_buf()].filetype == 'java' then
           local projectClassPattern = '.+/([^/]+)[.]java'
           local jdtClassPattern = '/([^/?=]+)[.]class'

--- a/lua/lspsaga/callhierarchy.lua
+++ b/lua/lspsaga/callhierarchy.lua
@@ -123,16 +123,25 @@ function ch:call_hierarchy(item, parent)
         local expand_collapse = '  ' .. ui.expand
         local icon = kind[target.kind][2]
 
-        local projectClassPattern = '.+/([^/]+)[.]java'
-        local jdtClassPattern = '/([^/?=]+)[.]class'
-        local projectClass = target.uri:match(projectClassPattern)
-        local jdtClass = target.uri:match(jdtClassPattern)
-        local className = projectClass or jdtClass
-        className = className and className or ''
+        -- Variable can be used to append name of class to the respective method in the outgoing preview popup.
+        local classNamePart = ''
+
+        -- Class name resolution for Java
+        -- 
+        if vim.bo[api.nvim_get_current_buf()].filetype == 'java' then
+          local projectClassPattern = '.+/([^/]+)[.]java'
+          local jdtClassPattern = '/([^/?=]+)[.]class'
+          local projectClass = target.uri:match(projectClassPattern)
+          local jdtClass = target.uri:match(jdtClassPattern)
+          local className = projectClass or jdtClass
+          if className ~= nil then
+            classNamePart = ' @ ' .. (className and className or '')
+          end
+        end
 
         self.data[#self.data + 1] = {
           target = target,
-          name = expand_collapse .. icon .. target.name .. ' @ ' .. className,
+          name = expand_collapse .. icon .. target.name .. classNamePart,
           highlights = {
             ['SagaCollapse'] = { 0, #expand_collapse },
             ['SagaWinbar' .. kind[target.kind][1]] = { #expand_collapse, #expand_collapse + #icon },

--- a/lua/lspsaga/callhierarchy.lua
+++ b/lua/lspsaga/callhierarchy.lua
@@ -127,7 +127,7 @@ function ch:call_hierarchy(item, parent)
         local classNamePart = ''
 
         -- Class name resolution for Java
-        if vim.bo[api.nvim_get_current_buf()].filetype == 'java' then
+        if vim.bo[self.main_buf].filetype == 'java' then
           local projectClassPattern = '.+/([^/]+)[.]java'
           local jdtClassPattern = '/([^/?=]+)[.]class'
           local projectClass = target.uri:match(projectClassPattern)

--- a/lua/lspsaga/callhierarchy.lua
+++ b/lua/lspsaga/callhierarchy.lua
@@ -122,8 +122,14 @@ function ch:call_hierarchy(item, parent)
         icons[#icons + 1] = kind[target.kind]
         local expand_collapse = '  ' .. ui.expand
         local icon = kind[target.kind][2]
-        local className = target.uri:match('.+/(.+)[.]class[?]')
+
+        local projectClassPattern = '.+/([^/]+)[.]java'
+        local jdtClassPattern = '/([^/?=]+)[.]class'
+        local projectClass = target.uri:match(projectClassPattern)
+        local jdtClass = target.uri:match(jdtClassPattern)
+        local className = projectClass or jdtClass
         className = className and className or ''
+
         self.data[#self.data + 1] = {
           target = target,
           name = expand_collapse .. icon .. target.name .. ' @ ' .. className,


### PR DESCRIPTION
## Why?
Some class names are not visible in `Lspsaga outgoing_calls` for methods which reside in classes, referenced in the project itself, i.e. by java source instead of by class file. We need to enhance the capturing of the class name in the preview window. 
The current code handles properly urls, which are:
>jdt://contents/slf4j-api-1.7.30.jar/org.slf4j/Logger.class?=server/%5C/Users%5C/user%5C/.m2%5C/repository%5C/org%5C/slf4j%5C/slf4j-api%5C/1.7.30%5C/slf4j-api-1.7.30.jar=/gradle_used_by_scope=/integrationTest,main,test=/%3Corg.slf4j(Logger.class

but the following urls are not handled properly:
>file:///Users/user/source/atlas/cloud-services-agents/vsphere-inventory-agent/server/src/main/java/com/company/product/cloud/inventory/monitor/MonitorRegistry.java

## What?
Enhance the regular expression for parsing the class name for the outgoing calls preview to capture properly in the case of java source file url.

## Testing Done
Before change:
![before](https://github.com/nvimdev/lspsaga.nvim/assets/1727634/d3b18264-216c-4415-9358-9ed8558461b2)
we can see the missing class names in the list of methods.
After change:
![after](https://github.com/nvimdev/lspsaga.nvim/assets/1727634/bc7cde63-5612-4434-8186-1cb1c1332dee)

We can see all class names properly.

as expected.