### PR TITLE
style: function symbol missing space

### DIFF
--- a/lua/lspsaga/lspkind.lua
+++ b/lua/lspsaga/lspkind.lua
@@ -40,7 +40,7 @@ local function get_kind()
     [9] = { 'Constructor', ' ', '@constructor' },
     [10] = { 'Enum', ' ', '@number' },
     [11] = { 'Interface', ' ', 'Type' },
-    [12] = { 'Function', '󰊕', 'Function' },
+    [12] = { 'Function', '󰊕 ', 'Function' },
     [13] = { 'Variable', ' ', '@variable' },
     [14] = { 'Constant', ' ', 'Constant' },
     [15] = { 'String', '󰅳 ', 'String' },

--- a/lua/lspsaga/lspkind.lua
+++ b/lua/lspsaga/lspkind.lua
@@ -40,7 +40,7 @@ local function get_kind()
     [9] = { 'Constructor', ' ', '@constructor' },
     [10] = { 'Enum', ' ', '@number' },
     [11] = { 'Interface', ' ', 'Type' },
-    [12] = { 'Function', '󰊕 ', 'Function' },
+    [12] = { 'Function', '󰡱 ', 'Function' },
     [13] = { 'Variable', ' ', '@variable' },
     [14] = { 'Constant', ' ', 'Constant' },
     [15] = { 'String', '󰅳 ', 'String' },


### PR DESCRIPTION
There was a missing space for the `function` symbol.
It could make sense to wrap them all into a function that adds the extra space or any pre/suffix

![fix](https://github.com/nvimdev/lspsaga.nvim/assets/43855513/b1b11b78-f25b-4d1e-a66f-09f7c95b00cb)
