### PR TITLE
add outline hide_kind config

### DIFF
--- a/lua/lspsaga/outline.lua
+++ b/lua/lspsaga/outline.lua
@@ -491,7 +491,12 @@ function ot:render_outline(buf, symbols)
 
   for k, v in pairs(res) do
     local scope = {}
-    local indent_with_icon = '  ' .. config.ui.collapse
+    local indent_with_icon = '  ' .. config.ui.collapse 
+    if outline_conf.hide_kind ~= nil then
+      if vim.tbl_contains(outline_conf.hide_kind,kind[k][1]) then
+        goto continue
+      end
+    end 
     lines[#lines + 1] = indent_with_icon .. ' ' .. kind[k][1] .. ':' .. #v.data
     scope['SagaCount'] = { #indent_with_icon + #kind[k][1] + 1, -1 }
     scope['SagaCollapse'] = { 0, #indent_with_icon }
@@ -510,6 +515,7 @@ function ot:render_outline(buf, symbols)
     end
     lines[#lines + 1] = ''
     hi[#hi + 1] = {}
+   ::continue::
   end
 
   api.nvim_buf_set_lines(self.bufnr, 0, -1, false, lines)


### PR DESCRIPTION
During the process of using it, I found that at some point, the outline displayed too many variables, which affected the reading of the code, so I added a hide_kind configuration item

The configuration method is like summer
```
outline = {
        auto_preview = false,
        win_width = 50,
        hide_kind={"Variable"},
        keys = {
          expand_or_jump = '<cr>',
        },
      },
```
