### PR TITLE
chore(definition): do not enter current buffer

### DIFF
--- a/lua/lspsaga/definition.lua
+++ b/lua/lspsaga/definition.lua
@@ -108,7 +108,9 @@ function def:apply_aciton_keys(buf, main_buf)
         if node.bufnr == main_buf and vim.bo[node.bufnr].modified then
           vim.cmd('write!')
         end
-        vim.cmd(action .. ' ' .. vim.uri_to_fname(node.uri))
+        if buf ~= main_buf then
+          vim.cmd(action .. ' ' .. vim.uri_to_fname(node.uri))
+        end
         if not node.wipe then
           self.restore_opts.restore()
         end


### PR DESCRIPTION
If go to definition happen on the same buffer, the `edit` command will close and enter the current buffer. That will hurt some REPL plugin (like https://github.com/kiyoon/jupynium.nvim) as it missunderstand you are quitting nvim.

This will resolve https://github.com/nvimdev/lspsaga.nvim/issues/1032