### PR TITLE
Add option to set initial mode for rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -485,7 +485,7 @@ Default options:
     exec = "<CR>",
     mark = "x",
     confirm = "<CR>",
-    in_select = true,
+    initial_mode = "s"
   },
 ```
 

--- a/doc/lspsaga.nvim.txt
+++ b/doc/lspsaga.nvim.txt
@@ -527,7 +527,7 @@ Default options:
         exec = "<CR>",
         mark = "x",
         confirm = "<CR>",
-        in_select = true,
+        initial_mode = "s"
       },
 <
 

--- a/lua/lspsaga/init.lua
+++ b/lua/lspsaga/init.lua
@@ -98,7 +98,7 @@ local default_config = {
     exec = '<CR>',
     mark = 'x',
     confirm = '<CR>',
-    in_select = true,
+    initial_mode = 's'
   },
   symbol_in_winbar = {
     enable = true,

--- a/lua/lspsaga/rename.lua
+++ b/lua/lspsaga/rename.lua
@@ -33,11 +33,9 @@ function rename:apply_action_keys()
   local modes = { 'i', 'n', 'v' }
 
   for i, mode in pairs(modes) do
-    if string.lower(config.rename.quit) ~= '<esc>' or mode == 'n' then
-      vim.keymap.set(mode, config.rename.quit, function()
-        self:close_rename_win()
-      end, { buffer = self.bufnr })
-    end
+    vim.keymap.set(mode, config.rename.quit, function()
+      self:close_rename_win()
+    end, { buffer = self.bufnr })
 
     if i ~= 3 then
       vim.keymap.set(mode, config.rename.exec, function()
@@ -156,9 +154,11 @@ function rename:lsp_rename(arg)
   self:set_local_options()
   api.nvim_buf_set_lines(self.bufnr, -2, -1, false, { cword })
 
-  if config.rename.in_select then
+  if config.rename.initial_mode == 's' then
     vim.cmd([[normal! V]])
     feedkeys('<C-g>', 'n')
+  elseif config.rename.initial_mode == 'i' then
+    vim.cmd([[startinsert!]])
   end
 
   local quit_id, close_unfocus


### PR DESCRIPTION
Thank you for providing such a great plugin.
I want to add an option to rename in insert mode because sometimes I want to change only a part of a variable or function name.