### PR TITLE
fix: finder cursor navigation

### DIFF
--- a/lua/lspsaga/finder.lua
+++ b/lua/lspsaga/finder.lua
@@ -484,6 +484,7 @@ function finder:create_finder_win(width)
           if node then
             curline = node.winline
             start = node.start
+            break
           end
         end
       elseif not in_fname then


### PR DESCRIPTION
Currently it is not possible to navigate up with cursor to the first entry of the finder. This small change fixes the bug.

before:


![before_changes](https://github.com/nvimdev/lspsaga.nvim/assets/53782948/bae0ed96-295f-4796-a693-f732d1a52b3f)

after:


![after_changes](https://github.com/nvimdev/lspsaga.nvim/assets/53782948/5703ac0e-b516-4d1f-9fe1-9be5d73396b6)

