### PR TITLE
Fix: outline not showing up when symbols are not ready

### DIFF
--- a/lua/lspsaga/symbol/init.lua
+++ b/lua/lspsaga/symbol/init.lua
@@ -79,7 +79,7 @@ function symbol:do_request(buf, client, callback)
     if not api.nvim_buf_is_loaded(ctx.bufnr) then
       return
     end
-    self[buf].pending_request = false
+    self[ctx.bufnr].pending_request = false
 
     if callback then
       callback(result)
@@ -90,6 +90,10 @@ function symbol:do_request(buf, client, callback)
     end
 
     self[ctx.bufnr].symbols = result
+    if self[ctx.bufnr].callback then
+      self[ctx.bufnr].callback({ symbols=result })
+      self[ctx.bufnr].callback = nil
+    end
     api.nvim_exec_autocmds('User', {
       pattern = 'SagaSymbolUpdate',
       modeline = false,
@@ -100,6 +104,10 @@ function symbol:do_request(buf, client, callback)
   if register then
     self:buf_watcher(buf, client)
   end
+end
+
+function symbol:register_callback(buf, cb)
+  self[buf].callback = cb
 end
 
 function symbol:get_buf_symbols(buf)

--- a/lua/lspsaga/symbol/outline.lua
+++ b/lua/lspsaga/symbol/outline.lua
@@ -383,15 +383,7 @@ function ot:clean_after_close()
   })
 end
 
-function ot:outline(buf)
-  if self.winid and api.nvim_win_is_valid(self.winid) then
-    api.nvim_win_close(self.winid, true)
-    clean_ctx()
-    return
-  end
-
-  self.main_buf = buf or api.nvim_get_current_buf()
-  local res = symbol:get_buf_symbols(self.main_buf)
+function ot:outline_parse(res)
   if not res or not res.symbols or #res.symbols == 0 then
     return
   end
@@ -418,6 +410,24 @@ function ot:outline(buf)
 
   if outline_conf.auto_close then
     self:auto_close(group)
+  end
+end
+
+function ot:outline(buf)
+  if self.winid and api.nvim_win_is_valid(self.winid) then
+    api.nvim_win_close(self.winid, true)
+    clean_ctx()
+    return
+  end
+
+  self.main_buf = buf or api.nvim_get_current_buf()
+  local res = symbol:get_buf_symbols(self.main_buf)
+  if res and res.symbols then
+    self:outline_parse(res)
+  else
+    symbol:register_callback(self.main_buf, function(t)
+      self:outline_parse(t)
+    end)
   end
 end
 


### PR DESCRIPTION
Some servers are very slow at startup. Outline will not show up when the symbols are not requested. Users may be confused  by `no response` of the command `:Lspsaga outline`. This commit will fix this. 