### PR TITLE
fix empty result in finder

### DIFF
--- a/lua/lspsaga/finder/init.lua
+++ b/lua/lspsaga/finder/init.lua
@@ -91,21 +91,8 @@ function fd:method_title(method, row)
   slist.tail_push(self.list, n)
 end
 
-local function is_empty(results)
-  -- handle {{}}
-  if vim.tbl_isempty(results) then
-    return true
-  end
-  for i, res in ipairs(results) do
-    if res.result and #res.result > 0 then
-      return false
-    end
-  end
-  return true
-end
-
 function fd:handler(method, results, spin_close, done)
-  if not results or is_empty(results) then
+  if not results or util.res_isempty(results) then
     spin_close()
     vim.notify(
       '[Lspsaga] No definition/reference',

--- a/lua/lspsaga/finder/init.lua
+++ b/lua/lspsaga/finder/init.lua
@@ -91,8 +91,26 @@ function fd:method_title(method, row)
   slist.tail_push(self.list, n)
 end
 
+local function is_empty(results)
+  -- handle {{}}
+  if vim.tbl_isempty(results) then
+    return true
+  end
+  for i, res in ipairs(results) do
+    if res.result and #res.result > 0 then
+      return false
+    end
+  end
+  return true
+end
+
 function fd:handler(method, results, spin_close, done)
-  if not results or vim.tbl_isempty(results) then
+  if not results or is_empty(results) then
+    spin_close()
+    vim.notify(
+      '[Lspsaga] No definition/reference',
+      vim.log.levels.WARN
+    )
     return
   end
   local rendered_fname = {}

--- a/lua/lspsaga/util.lua
+++ b/lua/lspsaga/util.lua
@@ -180,4 +180,17 @@ function M.map_keys(buffer, keys, rhs, modes, opts)
   end
 end
 
+function M.res_isempty(results)
+  -- handle {{}}
+  if vim.tbl_isempty(results) then
+    return true
+  end
+  for i, res in ipairs(results) do
+    if res.result and #res.result > 0 then
+      return false
+    end
+  end
+  return true
+end
+
 return M

--- a/test/util_spec.lua
+++ b/test/util_spec.lua
@@ -50,4 +50,9 @@ describe('lspsaga util', function()
     end
     is_true(true, created)
   end)
+
+  it('util.res_isempty', function()
+    local client_results = { { result = {} } }
+    assert.is_true(util.res_isempty(client_results))
+  end)
 end)


### PR DESCRIPTION
Call ":Lspsaga finder" at a dumb position will cause lspsaga stuck.
In this case, result given by lsp is like {{}}