### PR TITLE
fix(finder): restore winhl after buffer changes

### DIFF
--- a/lua/lspsaga/finder/init.lua
+++ b/lua/lspsaga/finder/init.lua
@@ -206,6 +206,10 @@ function fd:event()
         return
       end
       api.nvim_win_set_buf(self.rwinid, node.value.bufnr)
+      api.nvim_set_option_value('winhl', 'Normal:SagaNormal,FloatBorder:SagaBorder', {
+        scope = 'local',
+        win = self.rwinid,
+      })
       local range = node.value.selectionRange or node.value.range or node.value.targetSelectionRange
       api.nvim_win_set_cursor(self.rwinid, { range.start.line + 1, range.start.character })
       api.nvim_set_option_value('winbar', '', { scope = 'local', win = self.rwinid })


### PR DESCRIPTION
Turns out that after calling `nvim_win_set_buf` for a window, all local options will be overwritten. Wrote a fix to restore the original winhl after `nvim_win_set_buf`.