### PR TITLE
fix index of diagnostic

### DIFF
--- a/lua/lspsaga/diagnostic/init.lua
+++ b/lua/lspsaga/diagnostic/init.lua
@@ -52,7 +52,7 @@ function diag:get_diagnostic(opt)
   if opt.cursor then
     local res = {}
     for _, v in pairs(entrys) do
-      if v.col <= col and v.end_col >= col then
+      if v.col <= col and v.end_col > col then
         res[#res + 1] = v
       end
     end

--- a/lua/lspsaga/diagnostic/show.lua
+++ b/lua/lspsaga/diagnostic/show.lua
@@ -211,9 +211,9 @@ end
 local function msg_fmt(entry)
   return entry.message
     .. ' '
-    .. entry.lnum
+    .. entry.lnum + 1
     .. ':'
-    .. entry.col
+    .. entry.col + 1
     .. ':'
     .. entry.bufnr
     .. ' '
@@ -238,8 +238,8 @@ function sd:toggle_or_jump(entrys_list)
       api.nvim_win_set_buf(0, tonumber(bn))
       wins[#wins] = 0
     end
-    api.nvim_win_set_cursor(wins[#wins], { tonumber(ln) + 1, tonumber(col) })
-    beacon({ tonumber(ln), 0 }, #api.nvim_get_current_line())
+    api.nvim_win_set_cursor(wins[#wins], { tonumber(ln), tonumber(col) - 1 })
+    beacon({ tonumber(ln) - 1, 0 }, #api.nvim_get_current_line())
     clean_ctx()
     return
   end


### PR DESCRIPTION
The indexes of rows and columns are different from the actual ones：
![image](https://github.com/nvimdev/lspsaga.nvim/assets/92523839/92024a82-845e-49dc-83ef-027e1785626c)
When the mouse is behind the cursor, diagnostic should not be displayed：
![image](https://github.com/nvimdev/lspsaga.nvim/assets/92523839/8e5ea235-4dc6-4d0b-ab43-02967b3cc6d5)
Originally:
https://github.com/nvimdev/lspsaga.nvim/assets/92523839/585e0278-4cbe-4572-a040-f055df71d2de

After repair:
https://github.com/nvimdev/lspsaga.nvim/assets/92523839/bde3d271-7b1c-4c29-a7a1-7452946f6996

