### PR TITLE
Fix error on LspAttach

### DIFF
--- a/lua/lspsaga/symbol/init.lua
+++ b/lua/lspsaga/symbol/init.lua
@@ -167,7 +167,7 @@ function symbol:register_module()
         return
       end
 
-      local client = lsp.get_client_by_id(args.data.client_id)
+      local client = lsp.get_client_by_id(args.id)
       if not client then
         return
       end


### PR DESCRIPTION
It's not clear if this is the *correct* ID, but there's no `data` table on `args` so it crashes on `LspAttach`. This makes it go away, but I haven't validated that it doesn't break other behavior.