### PR TITLE
Fix exception with lsp_rename()

### DIFF
--- a/lua/lspsaga/rename/init.lua
+++ b/lua/lspsaga/rename/init.lua
@@ -77,7 +77,7 @@ local feedkeys = function(keys, mode)
   api.nvim_feedkeys(api.nvim_replace_termcodes(keys, true, true, true), mode, true)
 end
 
-local function parse_arugment(args)
+local function parse_argument(args)
   local mode, project
   for _, arg in ipairs(args) do
     if arg:find('mode=') then
@@ -92,7 +92,7 @@ end
 function rename:lsp_rename(args)
   local cword = fn.expand('<cword>')
   self.pos = api.nvim_win_get_cursor(0)
-  local mode, project = parse_arugment(args)
+  local mode, project = parse_argument(args)
 
   local float_opt = {
     height = 1,

--- a/lua/lspsaga/rename/init.lua
+++ b/lua/lspsaga/rename/init.lua
@@ -79,7 +79,8 @@ end
 
 local function parse_argument(args)
   local mode, project
-  for _, arg in ipairs(args) do
+
+  for _, arg in ipairs(args or {}) do
     if arg:find('mode=') then
       mode = vim.split(arg, '=', { trimempty = true })
     elseif arg:find('%+%+project') then


### PR DESCRIPTION
With 95ec55d I'm getting the following error when trying to rename a struct member in C:

```
E5108: Error executing lua: ...share/nvim/lazy/lspsaga.nvim/lua/lspsaga/rename/init.lua:82: bad argument #1 to 'ipairs' (table expected, got nil)                                    
stack traceback:                                                                                                                                                                     
        [C]: in function 'ipairs'                                                                                                                                                    
        ...share/nvim/lazy/lspsaga.nvim/lua/lspsaga/rename/init.lua:82: in function 'parse_arugment'                                                                                 
        ...share/nvim/lazy/lspsaga.nvim/lua/lspsaga/rename/init.lua:95: in function 'lsp_rename'                                                                                     
        /home/asn/.config/nvim/lua/lsp/on_attach.lua:264: in function </home/asn/.config/nvim/lua/lsp/on_attach.lua:263>
```

Here is my keymap:

```
        keymap('n', '<leader>lr', function()
            require('lspsaga.rename'):lsp_rename()
        end, { desc = 'rename [LSP]' })
```

This fixes it ...