### PR TITLE
Replace deprecated health methods

### DIFF
--- a/lua/lspsaga/health.lua
+++ b/lua/lspsaga/health.lua
@@ -3,23 +3,23 @@ local M = {}
 
 local function treesitter_check()
   if fn.executable('tree-sitter') == 0 then
-    health.report_warn('`tree-sitter` executable not found ')
+    health.warn('`tree-sitter` executable not found ')
   else
-    health.report_ok('`tree-sitter` found ')
+    health.ok('`tree-sitter` found ')
   end
 
   for _, parser in ipairs({ 'markdown', 'markdown_inline' }) do
     local installed = #api.nvim_get_runtime_file('parser/' .. parser .. '.so', false)
     if installed == 0 then
-      health.report_error('tree-sitter `' .. parser .. '` parser not found')
+      health.error('tree-sitter `' .. parser .. '` parser not found')
     else
-      health.report_ok('tree-sitter `' .. parser .. '` parser found')
+      health.ok('tree-sitter `' .. parser .. '` parser found')
     end
   end
 end
 
 M.check = function()
-  health.report_start('Lspsaga.nvim report')
+  health.start('Lspsaga.nvim report')
   treesitter_check()
 end
 


### PR DESCRIPTION
These methods [have been deprecated](https://neovim.io/doc/user/deprecated.html), and their use generates warnings when running `checkhealth`.

<img width="802" alt="image" src="https://github.com/nvimdev/lspsaga.nvim/assets/62502207/fb31e2e6-c49c-415f-83d7-fe1dee5d4a1a">
