### PR TITLE
finder: fix root path trim

### DIFF
--- a/lua/lspsaga/util.lua
+++ b/lua/lspsaga/util.lua
@@ -26,7 +26,7 @@ end
 function M.path_sub(fname, root)
   root = (root and fname:sub(1, #root) == root) and root or vim.env.HOME
   root = root:sub(#root - #M.path_sep + 1) == M.path_sep and root or root .. M.path_sep
-  return fname:sub(#root + 1)
+  return fname:gsub(vim.pesc(root), '')
 end
 
 --get icon hlgroup color

--- a/test/util_spec.lua
+++ b/test/util_spec.lua
@@ -70,5 +70,8 @@ describe('lspsaga util', function()
     root = '/Users/test/workspace/vue-project'
     res = util.path_sub('/Users/test/workspace/vue-project/src/main.vue', root)
     assert.is_equal('src/main.vue', res)
+    root = '/Users/test/(test-dir)/%proj-rs/'
+    res = util.path_sub('/Users/test/(test-dir)/%proj-rs/src/main.rs', root)
+    assert.is_equal('src/main.rs', res)
   end)
 end)


### PR DESCRIPTION
I noticed that finder window doesn't display path to the file correctly, sometimes in displays full path, which is no pleasant.

It turns out that the special characters in root path should be escaped with "%" https://www.reddit.com/r/lua/comments/jnoytk/comment/gb5dnkk/?utm_source=share&utm_medium=web2x&context=3

Thus, it is needed to handle special characters and convert root path string to pattern string by escaping special characters with "%"