### PR TITLE
Add space to code action title

### DIFF
--- a/lua/lspsaga/codeaction/init.lua
+++ b/lua/lspsaga/codeaction/init.lua
@@ -64,7 +64,7 @@ function act:action_callback(tuples, enriched_ctx)
 
   if config.ui.title then
     float_opt.title = {
-      { config.ui.code_action .. ' CodeActions', 'Title' },
+      { config.ui.code_action .. ' Code Actions', 'Title' },
       { ' ' .. #content .. ' ', 'SagaCount' },
     }
   end


### PR DESCRIPTION
It looks nicer to have a space between the 2 words 😄 