### PR TITLE
fix: spelling in notify messages

### DIFF
--- a/lua/lspsaga/callhierarchy.lua
+++ b/lua/lspsaga/callhierarchy.lua
@@ -111,7 +111,10 @@ end
 
 function ch:toggle_or_request()
   if self.pending_request then
-    vim.notify(('[Lspsaga] already have a request for %s'):format(self.method), vim.log.levels.WARN)
+    vim.notify(
+      ('[lspsaga] a request for %s has already been sent, please wait.'):format(self.method),
+      vim.log.levels.WARN
+    )
     return
   end
   local curlnum = api.nvim_win_get_cursor(0)[1]
@@ -389,13 +392,13 @@ end
 
 function ch:send_prepare_call()
   if self.pending_request then
-    vim.notify('there is already a request please wait.')
+    vim.notify('[lspsaga] a request has already been sent, please wait.')
     return
   end
   self.main_buf = api.nvim_get_current_buf()
   local clients = util.get_client_by_method(get_method(1))
   if #clients == 0 then
-    vim.notify('[Lspsaga] all clients of this buffer not support callhierarchy')
+    vim.notify('[lspsaga] callhierarchy is not supported by the clients of the current buffer')
     return
   end
   local client

--- a/lua/lspsaga/codeaction/init.lua
+++ b/lua/lspsaga/codeaction/init.lua
@@ -36,7 +36,7 @@ function act:action_callback(tuples, enriched_ctx)
   for index, client_with_actions in ipairs(tuples) do
     local action_title = ''
     if #client_with_actions ~= 2 then
-      vim.notify('There is something wrong in aciton_tuples')
+      vim.notify('[lspsaga] failed indexing client actions')
       return
     end
     if client_with_actions[2].title then
@@ -328,7 +328,7 @@ end
 function act:code_action(options)
   if self.pending_request then
     vim.notify(
-      '[lspsaga.nvim] there is already a code action request please wait',
+      '[lspsaga] a code action has already been requested, please wait.',
       vim.log.levels.WARN
     )
     return

--- a/lua/lspsaga/definition.lua
+++ b/lua/lspsaga/definition.lua
@@ -163,14 +163,14 @@ function def:clean_event()
         api.nvim_del_autocmd(args.id)
       end
     end,
-    desc = '[Lspsaga] peek definition clean data event',
+    desc = '[lspsaga] peek definition clean data event',
   })
 end
 
 function def:peek_definition(method)
   if self.pending_reqeust then
     vim.notify(
-      '[Lspsaga] There is already a peek_definition request, please wait for the response.',
+      '[lspsaga] a peek_definition request has already been sent, please wait.',
       vim.log.levels.WARN
     )
     return
@@ -199,7 +199,7 @@ function def:peek_definition(method)
     self.pending_request = false
     if not result or next(result) == nil then
       vim.notify(
-        '[Lspsaga] response of request method ' .. method_name .. ' is empty',
+        '[lspsaga] response of request method ' .. method_name .. ' is empty',
         vim.log.levels.WARN
       )
       return

--- a/lua/lspsaga/diagnostic/init.lua
+++ b/lua/lspsaga/diagnostic/init.lua
@@ -83,7 +83,7 @@ function diag:code_action_cb(action_tuples, enriched_ctx)
 
   for index, client_with_actions in pairs(action_tuples) do
     if #client_with_actions ~= 2 then
-      vim.notify('There is something wrong in aciton_tuples')
+      vim.notify('[lspsaga] failed indexing client actions')
       return
     end
     if client_with_actions[2].title then

--- a/lua/lspsaga/finder/box.lua
+++ b/lua/lspsaga/finder/box.lua
@@ -46,7 +46,7 @@ function M.filter(method, results)
   end
   local fn = config.finder.filter[method]
   if type(fn) ~= 'function' then
-    vim.notify('[Lspsaga] filter must be function', vim.log.levels.ERROR)
+    vim.notify('[lspsaga] filter must be a function', vim.log.levels.ERROR)
     return
   end
   local retval = {}

--- a/lua/lspsaga/finder/init.lua
+++ b/lua/lspsaga/finder/init.lua
@@ -33,7 +33,7 @@ local ns = api.nvim_create_namespace('SagaFinder')
 function fd:init_layout()
   local win_width = api.nvim_win_get_width(0)
   if config.finder.right_width > 0.6 then
-    vim.notify('[lspsaga] finder right width must less than 0.7')
+    vim.notify('[lspsaga] finder right width must be less than 0.7')
     config.finder.right_width = 0.5
   end
   self.lbufnr, self.lwinid, _, self.rwinid = ly:new(self.layout)
@@ -102,7 +102,7 @@ function fd:handler(method, results, spin_close, done)
   if not results or util.res_isempty(results) then
     spin_close()
     if not config.finder.silent then
-      vim.notify(('[Lspsaga] no response of %s'):format(method), vim.log.levels.WARN)
+      vim.notify(('[lspsaga] no response of %s'):format(method), vim.log.levels.WARN)
     end
     return
   end
@@ -471,7 +471,7 @@ function fd:new(args)
   self.ft = vim.bo[curbuf].filetype
   if #methods == 0 then
     vim.notify(
-      ('[Lspsaga] all server of %s buffer does not these methods %s'):format(
+      ('[lspsaga] no servers of buffer %s makes these methods available %s'):format(
         curbuf,
         table.concat(args, ' ')
       ),

--- a/lua/lspsaga/hover.lua
+++ b/lua/lspsaga/hover.lua
@@ -205,7 +205,7 @@ function hover:do_request(args)
   local clients = util.get_client_by_method(method)
   if #clients == 0 then
     self.pending_request = false
-    vim.notify('[Lspsaga] all server of buffer not support hover request')
+    vim.notify('[lspsaga] hover is not supported by the servers of the current buffer')
     return
   end
   local count = 0
@@ -318,14 +318,14 @@ end
 function hover:render_hover_doc(args)
   if not check_parser() then
     vim.notify(
-      '[Lpsaga.nvim] Please install markdown and markdown_inline parser in nvim-treesitter',
+      '[lspsaga] please install markdown and markdown_inline parser in nvim-treesitter',
       vim.log.levels.WARN
     )
     return
   end
 
   if self.pending_request then
-    print('[Lspsaga] There is already a hover request, please wait for the response.')
+    print('[lspsaga] a hover request has already been sent, please wait.')
     return
   end
 

--- a/lua/lspsaga/lspkind.lua
+++ b/lua/lspsaga/lspkind.lua
@@ -12,7 +12,7 @@ local function merge_custom(kind)
   for k, v in pairs(ui.kind or {}) do
     local index = find_index_by_type(k)
     if not index then
-      vim.notify('[lspsaga.nvim] could not find kind in default')
+      vim.notify('[lspsaga] failed finding kind in default')
       return
     end
     if type(v) == 'table' then
@@ -20,7 +20,7 @@ local function merge_custom(kind)
     elseif type(v) == 'string' then
       kind[index][3] = v
     else
-      vim.notify('[Lspsaga.nvim] value must be string or table')
+      vim.notify('[lspsaga] value must be of type string or table')
       return
     end
   end

--- a/lua/lspsaga/rename/init.lua
+++ b/lua/lspsaga/rename/init.lua
@@ -163,7 +163,7 @@ local function rename_handler(project, curname, new_name)
   lsp.handlers['textDocument/rename'] = function(err, result, ctx)
     if err then
       vim.notify(
-        '[Lspsaga] rename failed err in callback' .. table.concat(err),
+        '[lspsaga] rename failed err in callback' .. table.concat(err),
         vim.log.levels.ERROR
       )
       return

--- a/lua/lspsaga/rename/project.lua
+++ b/lua/lspsaga/rename/project.lua
@@ -144,12 +144,12 @@ end
 
 function M:new(args)
   if fn.executable('rg') == 0 then
-    vim.notify('[Lspsaga] does not find rg')
+    vim.notify('[lspsaga] failed finding rg')
     return
   end
 
   if #args < 2 then
-    vim.notify('[Lspsaga] missing search pattern or new name')
+    vim.notify('[lspsaga] missing search pattern or new name')
     return
   end
 
@@ -161,7 +161,7 @@ function M:new(args)
   local chunks = {}
   local root_dir = get_root_dir()
   if not root_dir then
-    vim.notify('[Lspsaga] buffer run in single file mode')
+    vim.notify('[lspsaga] buffer run in single file mode')
     return
   end
 

--- a/lua/lspsaga/symbol/outline.lua
+++ b/lua/lspsaga/symbol/outline.lua
@@ -511,7 +511,7 @@ function ot:outline(buf)
 
   if not res or not res.symbols or #res.symbols == 0 then
     vim.notify(
-      '[lspsaga] get symbols failed server may not initialed try again later',
+      '[lspsaga] failed finding symbols - server may not be initialized, try again later.',
       vim.log.levels.INFO
     )
     return


### PR DESCRIPTION
This PR submits fixes I found grepping through lspsagas notifications.
I got there after encountering spelling problems with some of the error messages I'm seeing lately.

It mainly fixes typos and phrasing. Also, the messages were made uniform. E.g. as prefix `[lspsaga]` `[lspsaga.nvim]` and `[Lspsaga]` was used - here I opted for a unifrom `[lspsaga]`. Please let me know if changes are desired.