### PR TITLE
fix symbols winbar when using get_bar(). follow up #1206

### DIFF
--- a/lua/lspsaga/symbol/winbar.lua
+++ b/lua/lspsaga/symbol/winbar.lua
@@ -224,7 +224,8 @@ end
 
 local function get_bar()
   local curbuf = api.nvim_get_current_buf()
-  local res = symbol:get_buf_symbols(curbuf)
+  local res = not util.nvim_ten() and symbol:get_buf_symbols(curbuf)
+    or require('lspsaga.symbol.head'):get_buf_symbols(curbuf)
   if res and res.symbols then
     return render_symbol_winbar(curbuf, res.symbols)
   end


### PR DESCRIPTION
A fix had previously been made for #1206 (see commit 1a38e4c), however the issue remained when using `get_bar()`  for custom components. This change addresses that use case and has been tested on neovim 0.9 and 0.10.