### PR TITLE
hotfix: Fall back to 1 when entry.col is nil

### DIFF
--- a/lua/lspsaga/diagnostic/init.lua
+++ b/lua/lspsaga/diagnostic/init.lua
@@ -268,8 +268,8 @@ function diag:render_diagnostic_window(entry, option)
     act:send_request(self.main_buf, {
       context = { diagnostics = self:get_cursor_diagnostic() },
       range = {
-        start = { entry.lnum + 1, entry.col },
-        ['end'] = { entry.lnum + 1, entry.col },
+        start = { entry.lnum + 1, (entry.col or 1) },
+        ['end'] = { entry.lnum + 1, (entry.col or 1) },
       },
       gitsign = false,
     }, function(action_tuples, enriched_ctx)
@@ -411,8 +411,8 @@ function diag:move_cursor(entry)
       end
     end
 
-    api.nvim_win_set_cursor(current_winid, { entry.lnum + 1, entry.col })
-    local width = entry.end_col - entry.col
+    api.nvim_win_set_cursor(current_winid, { entry.lnum + 1, (entry.col or 1) })
+    local width = entry.end_col - (entry.col or 1)
     if width <= 0 then
       width = #api.nvim_get_current_line()
     end


### PR DESCRIPTION
I want to fix this error.
<img width="1015" alt="Screen Shot 2023-08-10 at 0 21 36" src="https://github.com/nvimdev/lspsaga.nvim/assets/6651523/bbc6f74c-e855-4422-8e2f-7ccdfe93e189">

The error above occurs when I run `:Lspsaga diagnostic_jump_next` with the cursor on a line before the end of the file. 
If entry.col is nil, use 1 as a fallback.