### PR TITLE
do not pass _ as arguments in finder

### DIFF
--- a/lua/lspsaga/finder/init.lua
+++ b/lua/lspsaga/finder/init.lua
@@ -40,8 +40,8 @@ function fd:init_layout()
     :left(
       math.floor(vim.o.lines * config.finder.max_height),
       math.floor(win_width * config.finder.left_width),
-      _,
-      _,
+      nil,
+      nil,
       self.layout == 'normal' and config.finder.sp_global or nil
     )
     :bufopt({


### PR DESCRIPTION
_ is a global variable which can be assigned to. In fact, even here the global _ is assigned to:

https://github.com/defr0std/lspsaga.nvim/blob/8365520841a69111b8d7ae47fad5cbf88000885a/lua/lspsaga/finder/init.lua#L39

So the normal finder works just the first time. The second time, the _ variable can contain a bufnr, so the window is not initialized properly.

I also found other installed plugins which set the _ variable to various values such as empty string, empty table, etc.