### PR TITLE
open finder reference in the calling window

### DIFF
--- a/lua/lspsaga/finder/init.lua
+++ b/lua/lspsaga/finder/init.lua
@@ -31,6 +31,7 @@ end
 local ns = api.nvim_create_namespace('SagaFinder')
 
 function fd:init_layout()
+  self.callerwinid = api.nvim_get_current_win()
   local win_width = api.nvim_win_get_width(0)
   if config.finder.right_width > 0.6 then
     vim.notify('[lspsaga] finder right width must be less than 0.7')
@@ -328,13 +329,15 @@ function fd:toggle_or_open()
           client.offset_encoding
         ),
       }
+      local callerwinid = self.callerwinid
       self:clean()
       local restore = win:minimal_restore()
       local bufnr = vim.uri_to_bufnr(uri)
-      api.nvim_win_set_buf(0, bufnr)
+      api.nvim_win_set_buf(callerwinid, bufnr)
       vim.bo[bufnr].buflisted = true
       restore()
-      api.nvim_win_set_cursor(0, pos)
+      api.nvim_set_current_win(callerwinid)
+      api.nvim_win_set_cursor(callerwinid, pos)
       beacon({ pos[1] - 1, 0 }, #api.nvim_get_current_line())
       return
     end


### PR DESCRIPTION
This is a small convenience improvement. Currently, when the finder uses a normal layout with sp_global, the reference is always open ('toggle_or_open') in the leftmost window. This is quite inconvenient when working with multiple vertical splits. Imagine that you search for reference in the right split, and then the reference is open in the left split, which has a completely different context.

When the finder is open, we memorize the current window id. When the reference is opened, we use that window id instead of 0 (which by this time is already the leftmost).

For float layout, or normal with sp_global=false, there is no change in behavior.