### PR TITLE
fix outline autocommand group issue. follow up #1304

### DIFF
--- a/lua/lspsaga/symbol/outline.lua
+++ b/lua/lspsaga/symbol/outline.lua
@@ -33,6 +33,7 @@ end
 local function outline_in_float()
   local win_width = api.nvim_win_get_width(0)
   local curbuf = api.nvim_get_current_buf()
+  group = api.nvim_create_augroup('outline', { clear = true })
 
   return ly:new('float')
     :left(
@@ -61,6 +62,7 @@ local function outline_normal_win()
   vim.cmd(pos .. ' vnew')
   local winid, bufnr = api.nvim_get_current_win(), api.nvim_get_current_buf()
   api.nvim_win_set_width(winid, config.outline.win_width)
+  group = api.nvim_create_augroup('outline', { clear = true })
 
   return win
     :from_exist(bufnr, winid)


### PR DESCRIPTION
This fix address an error being thrown when reopening the outline, and is a follow up to #1304.
The autocommand group `outline` is initialised on line 18 of `outline.lua`.
The `clean_ctx()` function deletes the `outline` group by id (`nvim_del_augroup_by_id`). 
This function is called when closing the outline.
Attempting to reopen the outline causes an error to be thrown, as the autocommand group ID given has been deleted.
This fix recreates the `outline` group in the `outline_normal_win()` and `outline_in_float()` functions, allowing a valid ID to be used when the outline is refreshed. 
