### PR TITLE
Fix `peek_definition` when LS response is `Location`

### DIFF
--- a/lua/lspsaga/definition.lua
+++ b/lua/lspsaga/definition.lua
@@ -199,7 +199,7 @@ function def:definition_request(method, handler_T, args)
   local count = #util.get_client_by_method(method)
 
   lsp.buf_request(current_buf, method, params, function(_, result, context)
-    if not result or #result == 0 then
+    if not result or (vim.tbl_islist(result) and #result == 0) then
       self.pending_request = false
       return
     end


### PR DESCRIPTION
When the `result` is not tbl_list, `#result === 0` will always be true.

Fixes #1323