### PR TITLE
refactor: add missing SagaSep highlight

### DIFF
--- a/lua/lspsaga/highlight.lua
+++ b/lua/lspsaga/highlight.lua
@@ -14,6 +14,7 @@ local function hi_define()
     SagaSpinner = { link = 'Statement' },
     SagaText = { link = 'Comment' },
     SagaSelect = { link = 'String' },
+    SagaSep = { fg = 'white', bg = 'none' },
     SagaSearch = { link = 'Search' },
     SagaFinderFname = { link = 'Function' },
     SagaDetail = { link = 'Comment' },


### PR DESCRIPTION
## Description
This highlight is not defined by default which hides it from the user unless they check the source code in `lspasaga/winbar`