### PR TITLE
fix: jump to diagnostic with v.col is nil

### DIFF
--- a/lua/lspsaga/diagnostic/init.lua
+++ b/lua/lspsaga/diagnostic/init.lua
@@ -52,6 +52,9 @@ function diag:get_diagnostic(opt)
   if opt.cursor then
     local res = {}
     for _, v in pairs(entrys) do
+      if v.col == nil then
+        v.col = col
+      end
       if v.col <= col and (v.end_col and v.end_col > col or true) then
         res[#res + 1] = v
       end


### PR DESCRIPTION
I believe this PR will fix issue https://github.com/nvimdev/lspsaga.nvim/issues/1319. When the diagnostic appears in the beginning of line.

![lsp_diag_next](https://github.com/nvimdev/lspsaga.nvim/assets/40225276/d92b2a9f-ac94-4f70-8d76-940ae64de4e0)
