### PR TITLE
feat: add wrap_long_lines option for diagnostic window

### DIFF
--- a/lua/lspsaga/diagnostic/show.lua
+++ b/lua/lspsaga/diagnostic/show.lua
@@ -84,6 +84,7 @@ function sd:layout_normal()
       ['number'] = false,
       ['relativenumber'] = false,
       ['stc'] = '',
+      ['wrap'] = diag_conf.wrap_long_lines
     })
     :wininfo()
   api.nvim_win_set_height(self.winid, 10)
@@ -151,6 +152,7 @@ function sd:layout_float(opt)
     :winopt({
       ['conceallevel'] = 2,
       ['concealcursor'] = 'niv',
+      ['wrap'] = diag_conf.wrap_long_lines
     })
     :winhl('DiagnosticShowNormal', 'DiagnosticShowBorder')
     :wininfo()

--- a/lua/lspsaga/init.lua
+++ b/lua/lspsaga/init.lua
@@ -33,6 +33,7 @@ local default_config = {
     max_show_height = 0.6,
     text_hl_follow = true,
     border_follow = true,
+    wrap_long_lines = true,
     extend_relatedInformation = false,
     diagnostic_only_current = false,
     keys = {


### PR DESCRIPTION
Currently, if user uses `vim.opt.wrap = false` in their config and the line is too long, then it is impossible to display the whole diagnostic message.
![image](https://github.com/nvimdev/lspsaga.nvim/assets/28704185/d2dec1ce-de68-42af-9150-8a12f52bcf77)

This PR adds the ability to enable wrap in diagnostic window even though they use `vim.opt.wrap = false` in their config
![image](https://github.com/nvimdev/lspsaga.nvim/assets/28704185/7e391728-36b9-446d-9f3a-a0ebd4a8a170)