### PR TITLE
fix: show better diagnostic message

### DIFF
--- a/doc/lspsaga.nvim.txt
+++ b/doc/lspsaga.nvim.txt
@@ -1,4 +1,4 @@
-*lspsaga.nvim.txt*         For Nvim 0.8.0         Last change: 2024 January 05
+*lspsaga.nvim.txt*         For Nvim 0.8.0         Last change: 2024 January 20
 
 ==============================================================================
 Table of Contents                             *lspsaga.nvim-table-of-contents*

--- a/lua/lspsaga/diagnostic/show.lua
+++ b/lua/lspsaga/diagnostic/show.lua
@@ -84,7 +84,7 @@ function sd:layout_normal()
       ['number'] = false,
       ['relativenumber'] = false,
       ['stc'] = '',
-      ['wrap'] = diag_conf.wrap_long_lines
+      ['wrap'] = diag_conf.wrap_long_lines,
     })
     :wininfo()
   api.nvim_win_set_height(self.winid, 10)
@@ -152,7 +152,7 @@ function sd:layout_float(opt)
     :winopt({
       ['conceallevel'] = 2,
       ['concealcursor'] = 'niv',
-      ['wrap'] = diag_conf.wrap_long_lines
+      ['wrap'] = diag_conf.wrap_long_lines,
     })
     :winhl('DiagnosticShowNormal', 'DiagnosticShowBorder')
     :wininfo()
@@ -225,6 +225,7 @@ local function msg_fmt(entry)
     .. entry.bufnr
     .. ' '
     .. (entry.source and entry.source or '')
+    .. ' '
     .. (entry.code and entry.code or '')
 end
 


### PR DESCRIPTION
add a white space betweent diagnostic source and code
fix https://github.com/nvimdev/lspsaga.nvim/issues/1371