### PR TITLE
Add two options for winbar: show_nodes, and max_nodes

### DIFF
--- a/lua/lspsaga/init.lua
+++ b/lua/lspsaga/init.lua
@@ -124,6 +124,8 @@ local default_config = {
     folder_level = 1,
     color_mode = true,
     dely = 300,
+    show_nodes = true,
+    max_nodes = nil,
   },
   outline = {
     win_position = 'right',

--- a/lua/lspsaga/symbol/winbar.lua
+++ b/lua/lspsaga/symbol/winbar.lua
@@ -118,6 +118,10 @@ end
 
 --@private
 local function find_in_node(buf, tbl, line, elements)
+  if config.max_nodes and #elements >= config.max_nodes then
+    return
+  end
+
   local mid = binary_search(tbl, line)
   if not mid then
     return

--- a/lua/lspsaga/symbol/winbar.lua
+++ b/lua/lspsaga/symbol/winbar.lua
@@ -149,8 +149,9 @@ local function render_symbol_winbar(buf, symbols)
   local winbar_str = config.show_file and path_in_bar(buf) or ''
 
   local winbar_elements = {}
-
-  find_in_node(buf, symbols, current_line - 1, winbar_elements)
+  if config.show_nodes then
+    find_in_node(buf, symbols, current_line - 1, winbar_elements)
+  end
 
   local lens, over_idx = 0, 0
   local max_width = math.floor(api.nvim_win_get_width(cur_win) * 0.9)


### PR DESCRIPTION
I wanted to integrate the breadcrumbs into my lualine as a drop-in replacement for the filename module, these features make it more customizable and fit my usecase perfectly, their defaults are set to not affect any user that would update.