### PR TITLE
Fix: stop showing get_diagnostic when cursor exceed position

### DIFF
--- a/lua/lspsaga/diagnostic/init.lua
+++ b/lua/lspsaga/diagnostic/init.lua
@@ -52,7 +52,7 @@ function diag:get_diagnostic(opt)
   if opt.cursor then
     local res = {}
     for _, v in pairs(entrys) do
-      if v.col <= col and (v.end_col and v.end_col > col or true) then
+      if v.col <= col and (not v.end_col or v.end_col > col) then
         res[#res + 1] = v
       end
     end


### PR DESCRIPTION
This patch fixes the problem which diagnostics keeps on showing even when cursor position exceeds diagnosed area in get_diagnostic. It fixes the condition clause in get_diagnostic to correctly determine the cursor position to show.
This is a followup fix from Issue #1270.