### PR TITLE
fix: handle breaking change to vim.api.nvim_win_get_config (#1397)

### DIFF
--- a/lua/lspsaga/codeaction/preview.lua
+++ b/lua/lspsaga/codeaction/preview.lua
@@ -92,15 +92,26 @@ local preview_buf, preview_winid
 ---default is under the given window
 local function create_preview_win(content, main_winid)
   local win_conf = api.nvim_win_get_config(main_winid)
+
+  -- In versions of NVIM before v0.10.0 `api.nvim_win_get_config` will return a table for .col and .row
+  -- see https://github.com/neovim/neovim/issues/24430
+  if (type(win_conf.col) == "table") then
+    win_conf.col = win_conf.col[false]
+  end
+
+  if (type(win_conf.row) == "table") then
+    win_conf.row = win_conf.row[false]
+  end
+
   local max_height
   local opt = {
     relative = win_conf.relative,
     win = win_conf.win,
-    col = win_conf.col[false],
+    col = win_conf.col,
     anchor = win_conf.anchor,
     focusable = false,
   }
-  local max_width = api.nvim_win_get_width(win_conf.win) - win_conf.col[false] - 8
+  local max_width = api.nvim_win_get_width(win_conf.win) - win_conf.col - 8
   local content_width = util.get_max_content_length(content)
   if content_width > max_width then
     opt.width = max_width
@@ -110,10 +121,10 @@ local function create_preview_win(content, main_winid)
 
   local winheight = api.nvim_win_get_height(win_conf.win)
   if win_conf.anchor:find('^S') then
-    opt.row = win_conf.row[false] - win_conf.height - 2
-    max_height = win_conf.row[false] - win_conf.height
+    opt.row = win_conf.row - win_conf.height - 2
+    max_height = win_conf.row - win_conf.height
   elseif win_conf.anchor:find('^N') then
-    opt.row = win_conf.row[false] + win_conf.height + 2
+    opt.row = win_conf.row + win_conf.height + 2
     max_height = winheight - opt.row
   end
 


### PR DESCRIPTION
This PR fixes #1397, and adds support for the NVIM v0.10.0 `nvim_win_get_config()` API change.

It prioritizes the new API by making it the default and turning the return values into the v0.10.0 format if the user is running an older version of NVIM.

I've tested this locally and it fixes all the issues with code actions for me on `NVIM v0.10.0-dev-2393+g93c911e52-Homebrew` .