### PR TITLE
fix: fix small typo for string used when filtering clients by method

### DIFF
--- a/lua/lspsaga/rename/init.lua
+++ b/lua/lspsaga/rename/init.lua
@@ -49,7 +49,7 @@ function rename:find_reference()
   local bufnr = api.nvim_get_current_buf()
   local params = lsp.util.make_position_params()
   params.context = { includeDeclaration = true }
-  local clients = util.get_client_by_method('textDocment/references')
+  local clients = util.get_client_by_method('textDocument/references')
   if #clients == 0 then
     return
   end


### PR DESCRIPTION
Typo in the method argument. I think it goes unnoticed because nvim lsp just assumes the client supports the method if it can't find it when looking it up. See [here](https://github.com/neovim/neovim/blob/b413f5d048ab8676d5a77d0f2b3c20587a270673/runtime/lua/vim/lsp/client.lua#L860C3-L863C6).