### PR TITLE
fix: finder filter functions should work on items inside of result table rather than the result table as a whole

### DIFF
--- a/lua/lspsaga/finder/box.lua
+++ b/lua/lspsaga/finder/box.lua
@@ -50,7 +50,19 @@ function M.filter(method, results)
   end
   local retval = {}
   for client_id, item in pairs(results) do
-    retval[client_id] = { result = fn(item.result) }
+    -- NOTE: by the example, fn(client_id, result) is supp to return a bool
+    -- and if the results tbl = { { result = { {...}, {...}, ... } } }
+    -- likely want to allow user to filter using the members of the result table
+    -- rather than all the results
+    for _, result_member in ipairs(item.result) do
+      if fn(client_id, result_member) == true then
+        if retval[client_id] == nil then
+          retval[client_id] = { result = { result_member } }
+        else
+          table.insert(retval[client_id].result, result_member)
+        end
+      end
+    end
   end
   return retval
 end


### PR DESCRIPTION
PR should fix #1394. Below is the example in the docs for filtering in the finder. Since it's specified that func should return a bool, I *think* the func is meant to be called on each element of the `result` table rather than the `result` table itself (which itself is just part of the map returned by `vim.lsp.buf_request_all()`; the reuse of names is confusing). This way, I think it's more like the user can write filters that act on the finder results. Correct me if I'm wrong.

Additionally, `fn()` in `box.filter` should also take `client_id` so that filters are applied properly.

If all looks good, I can clean up comments and/or change the name of `result_member` variable to something else.

```lua
require('lspsaga').setup({
  finder = {
    filter = {
      ['textDocument/references']  = function(client_id, result)
        -- your logic
        return true
      end
    }
  }
})
```