### PR TITLE
Fix winbar.lua highlight when on a blank line.

### DIFF
--- a/lua/lspsaga/symbol/winbar.lua
+++ b/lua/lspsaga/symbol/winbar.lua
@@ -28,7 +28,7 @@ local function path_in_bar(buf)
 
   for item in util.path_itera(buf) do
     item = #items == 0
-        and '%#' .. (hl or 'SagaFileIcon') .. '#' .. (icon and icon .. ' ' or '') .. '%*' .. bar.prefix .. 'FileName#' .. item .. '%*'
+        and '%#' .. (hl or 'SagaFileIcon') .. '#' .. (icon and icon .. ' ' or '') .. '%*' .. bar.prefix .. 'FileName#' .. item
       or bar.prefix
         .. 'Folder#'
         .. (folder and folder or '')


### PR DESCRIPTION
Whenever the winbar didnt have any items to show (and it results to only folder/filename), it broke out of the filename highlight group, which with some themes would result in a black bar after the filename.

I noticed it doesn't break the highlight group when it actually does display the cursor's context, so maybe i revealed a bug ¯\_(ツ)_/¯