### PR TITLE
refactor(codeaction): border margin handling + CodeActionCursorLine highlight

### DIFF
--- a/lua/lspsaga/codeaction/init.lua
+++ b/lua/lspsaga/codeaction/init.lua
@@ -94,8 +94,6 @@ function act:action_callback(tuples, enriched_ctx)
   -- initial position in code action window
   api.nvim_win_set_cursor(self.action_winid, { 1, 1 })
 
-  vim.opt.winhl:append('CursorLine:SagaCursorLine')
-
   api.nvim_create_autocmd('CursorMoved', {
     buffer = self.action_bufnr,
     callback = function()
@@ -103,6 +101,7 @@ function act:action_callback(tuples, enriched_ctx)
     end,
   })
 
+  vim.opt.winhl:append('CursorLine:CodeActionCursorLine')
   for i = 1, #content, 1 do
     local row = i - 1
     local col = content[i]:find('%]')

--- a/lua/lspsaga/codeaction/init.lua
+++ b/lua/lspsaga/codeaction/init.lua
@@ -87,6 +87,7 @@ function act:action_callback(tuples, enriched_ctx)
       ['conceallevel'] = 2,
       ['concealcursor'] = 'niv',
       ['cursorline'] = config.code_action.cursorline,
+      ['cursorlineopt'] = 'both',
     })
     :winhl('SagaNormal', 'SagaBorder')
     :wininfo()

--- a/lua/lspsaga/codeaction/init.lua
+++ b/lua/lspsaga/codeaction/init.lua
@@ -86,6 +86,7 @@ function act:action_callback(tuples, enriched_ctx)
     :winopt({
       ['conceallevel'] = 2,
       ['concealcursor'] = 'niv',
+      ['cursorline'] = config.code_action.cursorline,
     })
     :winhl('SagaNormal', 'SagaBorder')
     :wininfo()

--- a/lua/lspsaga/codeaction/init.lua
+++ b/lua/lspsaga/codeaction/init.lua
@@ -93,6 +93,8 @@ function act:action_callback(tuples, enriched_ctx)
   -- initial position in code action window
   api.nvim_win_set_cursor(self.action_winid, { 1, 1 })
 
+  vim.opt.winhl:append('CursorLine:SagaCursorLine')
+
   api.nvim_create_autocmd('CursorMoved', {
     buffer = self.action_bufnr,
     callback = function()

--- a/lua/lspsaga/codeaction/preview.lua
+++ b/lua/lspsaga/codeaction/preview.lua
@@ -111,7 +111,7 @@ local function create_preview_win(content, main_winid)
   end
 
   local winheight = api.nvim_win_get_height(win_conf.win)
-  local win_margin = (config.ui.border == 'none') and 0 or 2
+  local win_margin = config.ui.border == 'none' and 0 or 2
   if win_conf.anchor:find('^S') then
     opt.row = util.is_ten and win_conf.row - 3 or win_conf.row[false] - win_conf.height - win_margin
     max_height = util.is_ten and win_conf.row or win_conf.row[false] - win_conf.height

--- a/lua/lspsaga/codeaction/preview.lua
+++ b/lua/lspsaga/codeaction/preview.lua
@@ -112,10 +112,10 @@ local function create_preview_win(content, main_winid)
 
   local winheight = api.nvim_win_get_height(win_conf.win)
   if win_conf.anchor:find('^S') then
-    opt.row = util.is_ten and win_conf.row - 3 or win_conf.row[false] - win_conf.height - 2
+    opt.row = util.is_ten and win_conf.row - 3 or win_conf.row[false] - win_conf.height - 0
     max_height = util.is_ten and win_conf.row or win_conf.row[false] - win_conf.height
   elseif win_conf.anchor:find('^N') then
-    opt.row = util.is_ten and win_conf.row + 3 or win_conf.row[false] + win_conf.height + 2
+    opt.row = util.is_ten and win_conf.row + 3 or win_conf.row[false] + win_conf.height + 0
     max_height = winheight - opt.row
   end
 

--- a/lua/lspsaga/codeaction/preview.lua
+++ b/lua/lspsaga/codeaction/preview.lua
@@ -111,11 +111,12 @@ local function create_preview_win(content, main_winid)
   end
 
   local winheight = api.nvim_win_get_height(win_conf.win)
+  local win_margin = (config.ui.border == 'none') and 0 or 2
   if win_conf.anchor:find('^S') then
-    opt.row = util.is_ten and win_conf.row - 3 or win_conf.row[false] - win_conf.height - 0
+    opt.row = util.is_ten and win_conf.row - 3 or win_conf.row[false] - win_conf.height - win_margin
     max_height = util.is_ten and win_conf.row or win_conf.row[false] - win_conf.height
   elseif win_conf.anchor:find('^N') then
-    opt.row = util.is_ten and win_conf.row + 3 or win_conf.row[false] + win_conf.height + 0
+    opt.row = util.is_ten and win_conf.row + 3 or win_conf.row[false] + win_conf.height + win_margin
     max_height = winheight - opt.row
   end
 

--- a/lua/lspsaga/highlight.lua
+++ b/lua/lspsaga/highlight.lua
@@ -28,6 +28,7 @@ local function hi_define()
     ActionPreviewTitle = { link = 'Title' },
     CodeActionText = { link = '@variable' },
     CodeActionNumber = { link = 'DiffAdd' },
+    CodeActionCursorLine = { link = 'CursorLine' },
     -- hover
     HoverNormal = { link = 'SagaNormal' },
     HoverBorder = { link = 'SagaBorder' },

--- a/lua/lspsaga/init.lua
+++ b/lua/lspsaga/init.lua
@@ -49,6 +49,7 @@ local default_config = {
     extend_gitsigns = false,
     only_in_cursor = true,
     max_height = 0.3,
+    cursorline = true,
     keys = {
       quit = 'q',
       exec = '<CR>',


### PR DESCRIPTION
I changed the hard coded margin between preview and code actions to make it 0 whenever `ui.border == 'none'`.

I also made a `code_action.cursorline` option defaulting to `true`. This feels like a more sane default since it's more of a 'completion-like' UI.

Let me know if you think it's okay, I will then update docs and other things if required!

## Before without borders

https://github.com/nvimdev/lspsaga.nvim/assets/39461169/63bc31f7-1a94-4e80-8654-a9e4f3a45000

## After without borders

https://github.com/nvimdev/lspsaga.nvim/assets/39461169/465ea5c4-927e-4eda-af84-85d6f1bb8249

## After with borders (and default highlights)

https://github.com/nvimdev/lspsaga.nvim/assets/39461169/7460e32c-83d2-4e70-af49-e48a1b48fef6

