### PR TITLE
feat: add padding+hl to code_action servers

### DIFF
--- a/lua/lspsaga/codeaction/init.lua
+++ b/lua/lspsaga/codeaction/init.lua
@@ -124,7 +124,7 @@ function act:action_callback(tuples, enriched_ctx)
   for i = 1, #content, 1 do
     local row = i - 1
     local col = content[i]:find('%]')
-    local server_start = content[i]:find('%(', max_len) - 1
+    local server_start = (content[i]:find('%(', max_len) or 1) - 1
     api.nvim_buf_add_highlight(self.action_bufnr, 0, 'CodeActionServer', row, server_start, -1)
     api.nvim_buf_add_highlight(self.action_bufnr, -1, 'CodeActionText', row, 0, -1)
     api.nvim_buf_add_highlight(self.action_bufnr, 0, 'CodeActionNumber', row, 0, col)

--- a/lua/lspsaga/codeaction/init.lua
+++ b/lua/lspsaga/codeaction/init.lua
@@ -32,6 +32,8 @@ function act:action_callback(tuples, enriched_ctx)
   end
 
   local content = {}
+  local servers = {}
+  local max_len = 0
 
   for index, client_with_actions in ipairs(tuples) do
     local action_title = ''
@@ -42,17 +44,33 @@ function act:action_callback(tuples, enriched_ctx)
     if client_with_actions[2].title then
       action_title = '[' .. index .. '] ' .. clean_msg(client_with_actions[2].title)
     end
+
     if config.code_action.show_server_name == true then
       if type(client_with_actions[1]) == 'string' then
-        action_title = action_title .. '  (' .. client_with_actions[1] .. ')'
+        table.insert(servers, client_with_actions[1])
       else
-        action_title = action_title
-          .. '  ('
-          .. lsp.get_client_by_id(client_with_actions[1]).name
-          .. ')'
+        table.insert(servers, lsp.get_client_by_id(client_with_actions[1]).name)
+      end
+
+      if #action_title > max_len then
+        max_len = #action_title
       end
     end
+
     content[#content + 1] = action_title
+  end
+
+  if config.code_action.show_server_name == true then
+    for i, server in ipairs(servers) do
+      local diff_len = max_len - #content[i] + 3
+
+      local padding = ''
+      for _ = 1, diff_len do
+        padding = padding .. ' '
+      end
+
+      content[i] = content[i] .. padding .. '(' .. server .. ')'
+    end
   end
 
   local max_height = math.floor(api.nvim_win_get_height(0) * config.code_action.max_height)
@@ -106,6 +124,8 @@ function act:action_callback(tuples, enriched_ctx)
   for i = 1, #content, 1 do
     local row = i - 1
     local col = content[i]:find('%]')
+    local server_start = content[i]:find('%(', max_len) - 1
+    api.nvim_buf_add_highlight(self.action_bufnr, 0, 'CodeActionServer', row, server_start, -1)
     api.nvim_buf_add_highlight(self.action_bufnr, -1, 'CodeActionText', row, 0, -1)
     api.nvim_buf_add_highlight(self.action_bufnr, 0, 'CodeActionNumber', row, 0, col)
   end

--- a/lua/lspsaga/highlight.lua
+++ b/lua/lspsaga/highlight.lua
@@ -29,6 +29,7 @@ local function hi_define()
     CodeActionText = { link = '@variable' },
     CodeActionNumber = { link = 'DiffAdd' },
     CodeActionCursorLine = { link = 'CursorLine' },
+    CodeActionServer = { link = 'Comment' },
     -- hover
     HoverNormal = { link = 'SagaNormal' },
     HoverBorder = { link = 'SagaBorder' },


### PR DESCRIPTION
* Added padding before the showing server name for better readability
* Created a new highlight group for server names

---

**Before**
<img width="430" alt="image" src="https://github.com/nvimdev/lspsaga.nvim/assets/56918431/be448a5c-4bf6-4724-a246-8465259ea753">


**After**
<img width="403" alt="image" src="https://github.com/nvimdev/lspsaga.nvim/assets/56918431/0915366a-870c-4536-9f73-166fffe8bba2">


---

**Before**
<img width="327" alt="image" src="https://github.com/nvimdev/lspsaga.nvim/assets/56918431/02d0fc43-9238-441e-ad34-36e7112b3a15">


**After**
<img width="329" alt="image" src="https://github.com/nvimdev/lspsaga.nvim/assets/56918431/6dc9014c-e2b9-4dfe-bb0d-f2763edd2232">
