### PR TITLE
Change rename so that curser in insert mode at the end of variable name

### DIFF
--- a/lua/lspsaga/rename/init.lua
+++ b/lua/lspsaga/rename/init.lua
@@ -122,9 +122,10 @@ function rename:lsp_rename(args)
 
   if mode == 'i' then
     vim.cmd.startinsert()
+    vim.cmd([[normal! $]])
   elseif mode == 's' or config.rename.in_select then
-    vim.cmd([[normal! V]])
-    feedkeys('<C-g>', 'n')
+    vim.cmd.startinsert()
+    vim.cmd([[normal! $]])
   end
 
   local quit_id, close_unfocus


### PR DESCRIPTION
Quality of life improvement;

I feel like this is more intuitive, as when a rename is made, more often than not, it's not a complete rename, it's just a partial change to the name.

If you don't agree with this change, would you be open to implementing this as an option the user can set instead?