### PR TITLE
Use nx mode to avoid remap keys

### DIFF
--- a/lua/lspsaga/util.lua
+++ b/lua/lspsaga/util.lua
@@ -75,7 +75,7 @@ end
 
 function M.feedkeys(key)
   local k = api.nvim_replace_termcodes(key, true, false, true)
-  api.nvim_feedkeys(k, 'x', false)
+  api.nvim_feedkeys(k, 'nx', false)
 end
 
 function M.scroll_in_float(bufnr, winid)


### PR DESCRIPTION
This PR try to use 'nx' mode for feedkeys to avoid remap keys. So scroll keys won't break with user's mappings.