### PR TITLE
fix: split diagnostic lines on \n character in floating window

### DIFF
--- a/lua/lspsaga/diagnostic/show.lua
+++ b/lua/lspsaga/diagnostic/show.lua
@@ -293,7 +293,7 @@ function sd:show(opt)
     curnode.expand = true
     for i, entry in ipairs(curnode.diags) do
       local virt_start = i == #curnode.diags and ui.lines[1] or ui.lines[2]
-      local mes = msg_fmt(entry)
+
       if i == 1 then
         ---@diagnostic disable-next-line: param-type-mismatch
         local fname = fn.fnamemodify(api.nvim_buf_get_name(tonumber(entry.bufnr)), ':t')
@@ -310,8 +310,26 @@ function sd:show(opt)
         count = count + 1
         curnode.lnum = count
       end
-      self:write_line(mes, entry.severity, virt_start, count)
-      count = count + 1
+
+      local messages = vim.split(entry.message, '\n')
+      for j, message in ipairs(messages) do
+        local mes = ''
+        if j == 1 then
+          mes = msg_fmt({
+            message = message,
+            lnum = entry.lnum,
+            col = entry.col,
+            bufnr = entry.bufnr,
+            source = entry.source,
+            code = entry.code,
+          })
+        else
+          mes = ' ' .. message
+        end
+
+        self:write_line(mes, entry.severity, virt_start, count)
+        count = count + 1
+      end
     end
     curnode = curnode.next
   end


### PR DESCRIPTION
This PR attempts to help display diagnostic messages in a more graceful way.

Before, newline characters ('\n') in diagnostic messages were simply stripped out. This PR instead writes them out to a separate line

**Before**
<img width="1273" alt="Screenshot 2024-05-11 at 7 52 29 AM" src="https://github.com/nvimdev/lspsaga.nvim/assets/1541411/f326f2b4-6379-4559-b823-40348f6a0dc2">

**After**
<img width="835" alt="Screenshot 2024-05-11 at 7 55 40 AM" src="https://github.com/nvimdev/lspsaga.nvim/assets/1541411/6ec90028-544b-431b-a890-f9b465857a58">

Ideally, it'd be nice to not display the horizontal lines so it's more clear certain lines are meant to be grouped together but I wasn't entirely sure how to do that.

Open to feedback!
