### PR TITLE
fix: escape char % is not handled

### DIFF
--- a/lua/lspsaga/symbol/winbar.lua
+++ b/lua/lspsaga/symbol/winbar.lua
@@ -27,6 +27,9 @@ local function path_in_bar(buf)
   end
 
   for item in util.path_itera(buf) do
+    if string.find(item, '%%') then
+      item = item:gsub('%%', '%%%%')
+    end
     item = #items == 0
         and '%#' .. (hl or 'SagaFileIcon') .. '#' .. (icon and icon .. ' ' or '') .. '%*' .. bar.prefix .. 'FileName#' .. item
       or bar.prefix


### PR DESCRIPTION
origin pr is https://github.com/nvimdev/lspsaga.nvim/pull/1363, but seems it is missing, so I pr it again

close: https://github.com/nvimdev/lspsaga.nvim/issues/1362