### PR TITLE
feat: add lightbulb.ignore options

### DIFF
--- a/lua/lspsaga/codeaction/lightbulb.lua
+++ b/lua/lspsaga/codeaction/lightbulb.lua
@@ -100,6 +100,12 @@ local function lb_autocmd()
       if not client.supports_method('textDocument/codeAction') then
         return
       end
+      if vim.tbl_contains(config.lightbulb.ignore.clients, client.name) then
+        return
+      end
+      if vim.tbl_contains(config.lightbulb.ignore.ft, vim.bo.filetype) then
+        return
+      end
 
       local buf = opt.buf
       local group_name = name .. tostring(buf)

--- a/lua/lspsaga/init.lua
+++ b/lua/lspsaga/init.lua
@@ -60,6 +60,10 @@ local default_config = {
     sign_priority = 40,
     virtual_text = true,
     enable_in_insert = true,
+    ignore = {
+      clients = {},
+      ft = {},
+    },
   },
   scroll_preview = {
     scroll_down = '<C-f>',


### PR DESCRIPTION
Ignore some lsp clients or filetypes, the option is the same as https://github.com/kosayoda/nvim-lightbulb