### PR TITLE
activate winbar symbols when opening file

### DIFF
--- a/lua/lspsaga/symbol/init.lua
+++ b/lua/lspsaga/symbol/init.lua
@@ -182,6 +182,14 @@ end
 
 function symbol:register_module()
   local group = api.nvim_create_augroup('LspsagaSymbols', { clear = true })
+  api.nvim_create_autocmd('FileType', {
+    group = group,
+    callback = function(args)
+      if config.symbol_in_winbar.enable then
+        require('lspsaga.symbol.winbar').init_winbar(args.buf)
+      end
+    end,
+  })
   api.nvim_create_autocmd('LspAttach', {
     group = group,
     callback = function(args)
@@ -195,17 +203,13 @@ function symbol:register_module()
       end
       self:do_request(args.buf, args.data.client_id)
 
-      if config.symbol_in_winbar.enable then
-        require('lspsaga.symbol.winbar').init_winbar(args.buf)
-      end
-
       if config.implement.enable and client.supports_method('textDocument/implementation') then
         require('lspsaga.implement').start()
       end
     end,
   })
 
-  api.nvim_create_autocmd('LspDetach', {
+  api.nvim_create_autocmd({ 'LspDetach', 'BufDelete' }, {
     group = group,
     callback = function(args)
       if self[args.buf] then


### PR DESCRIPTION
Hi, I noticed that the winbar can be populated right after opening a file. But LspSaga waits until `LspAttach`, which can sometimes take a while for some LSP servers.

But also, by not requiring the `LspAttach` event, the winbar works on files with no LSP server, at least just for the folder, filename, and filetype, which looks nice.

Notes on changes:
* I used `FileType` instead of `BufReadPost` below since sometimes the filetype was not available on `BufReadPost`.
* I'm not sure why there are two files `head.lua` and `init.lua`, but I made changes to both. seems like much of the code here can be consolidated.