### PR TITLE
fix(#1473): Update hover.lua -- missing lsp.Handler parameter

### DIFF
--- a/lua/lspsaga/hover.lua
+++ b/lua/lspsaga/hover.lua
@@ -231,7 +231,7 @@ function hover:do_request(args)
   end
   local count = 0
 
-  _, self.cancel = lsp.buf_request(0, method, params, function(_, result, ctx)
+  _, self.cancel = lsp.buf_request(0, method, params, function(_, result, ctx, _)
     count = count + 1
 
     if api.nvim_get_current_buf() ~= ctx.bufnr then


### PR DESCRIPTION
I believe the missing parameter was causing #1473
I could be wrong about this being the right fix, but providing the parameter fixed the issue for me.