### PR TITLE
bug with opening projects embedded in other projects

### DIFF
--- a/lua/lspsaga/rename/init.lua
+++ b/lua/lspsaga/rename/init.lua
@@ -122,9 +122,10 @@ function rename:lsp_rename(args)
 
   if mode == 'i' then
     vim.cmd.startinsert()
+    vim.cmd([[normal! $]])
   elseif mode == 's' or config.rename.in_select then
-    vim.cmd([[normal! V]])
-    feedkeys('<C-g>', 'n')
+    vim.cmd.startinsert()
+    vim.cmd([[normal! $]])
   end
 
   local quit_id, close_unfocus


### PR DESCRIPTION
In the following senario;

```
outter project/
├─ .git
├─ README.me
├─ src/
├─ inner project/
│  ├─ .git
│  ├─ README.me
│  ├─ src/
```

Assuming both the `outter project` and `inner project` are of the same langauge;
if you were to open the `outter project` first, then open the `inner project`, both projects would have the same `root directory`

This is causing issues with other plugins that rely on `root directory` to be accurate; 
https://github.com/ahmedkhalf/project.nvim/blob/8c6bad7d22eef1b71144b401c9f74ed01526a4fb/lua/project_nvim/project.lua#L25

This commit fixes the above described issue