### PR TITLE
fix: Use offset encoding of first client

### DIFF
--- a/lua/lspsaga/codeaction/init.lua
+++ b/lua/lspsaga/codeaction/init.lua
@@ -169,16 +169,18 @@ function act:send_request(main_buf, options, callback)
   end
   local params
   local mode = api.nvim_get_mode().mode
+  local client = vim.lsp.get_clients({ bufnr = main_buf })[1]
+  local offset_encoding = client and client.offset_encoding or 'utf-16'
   if options.range then
     assert(type(options.range) == 'table', 'code_action range must be a table')
     local start = assert(options.range.start, 'range must have a `start` property')
     local end_ = assert(options.range['end'], 'range must have a `end` property')
-    params = lsp.util.make_given_range_params(start, end_)
+    params = lsp.util.make_given_range_params(start, end_, offset_encoding)
   elseif mode == 'v' or mode == 'V' then
     local range = range_from_selection(0, mode)
     params = lsp.util.make_given_range_params(range.start, range['end'])
   else
-    params = lsp.util.make_range_params()
+    params = lsp.util.make_range_params(0, offset_encoding)
   end
 
   params.context = context

--- a/lua/lspsaga/codeaction/lightbulb.lua
+++ b/lua/lspsaga/codeaction/lightbulb.lua
@@ -106,7 +106,9 @@ end
 
 local function render(bufnr)
   local row = api.nvim_win_get_cursor(0)[1] - 1
-  local params = lsp.util.make_range_params()
+  local client = vim.lsp.get_clients({ bufnr = bufnr })[1]
+  local offset_encoding = client and client.offset_encoding or 'utf-16'
+  local params = lsp.util.make_range_params(0, offset_encoding)
   params.context = {
     diagnostics = diagnostic_vim_to_lsp(vim.diagnostic.get(bufnr, { lnum = row })),
   }


### PR DESCRIPTION
I fixed this error(`position_encoding param is required in vim.lsp.util.make_range_params. Defaulting to position encoding of the first client.`) that was occurring on nightly.

If using the 'stable release' version, there were no arguments for `make_range_params`, so it was not necessary to branch by version.

ref: https://github.com/neovim/neovim/pull/31249