### PR TITLE
fix: add missing parameter to `make_given_range_params`

### DIFF
--- a/lua/lspsaga/codeaction/init.lua
+++ b/lua/lspsaga/codeaction/init.lua
@@ -175,7 +175,7 @@ function act:send_request(main_buf, options, callback)
     assert(type(options.range) == 'table', 'code_action range must be a table')
     local start = assert(options.range.start, 'range must have a `start` property')
     local end_ = assert(options.range['end'], 'range must have a `end` property')
-    params = lsp.util.make_given_range_params(start, end_, offset_encoding)
+    params = lsp.util.make_given_range_params(start, end_, nil, offset_encoding)
   elseif mode == 'v' or mode == 'V' then
     local range = range_from_selection(0, mode)
     params = lsp.util.make_given_range_params(range.start, range['end'])


### PR DESCRIPTION
Fixes #1507 

In https://github.com/nvimdev/lspsaga.nvim/pull/1506 the offset was added to `make_given_range_params`, but the signature of the function is:

```lua
function M.make_given_range_params(start_pos, end_pos, bufnr, offset_encoding)
```

Which in servers like `clangd` was causing this issue:
```
Error executing vim.schedule lua callback: .../neovim/0.10.2_1/share/nvim/runtime/lua/vim/lsp/util.lua:2074: bufnr: expected number, got string
stack traceback:
	[C]: in function 'error'
	vim/shared.lua: in function 'validate'
	.../neovim/0.10.2_1/share/nvim/runtime/lua/vim/lsp/util.lua:2074: in function '_get_offset_encoding'
	.../neovim/0.10.2_1/share/nvim/runtime/lua/vim/lsp/util.lua:2148: in function 'make_given_range_params'
	...e/nvim/lazy/lspsaga.nvim/lua/lspsaga/codeaction/init.lua:178: in function 'send_request'
	...e/nvim/lazy/lspsaga.nvim/lua/lspsaga/diagnostic/init.lua:300: in function <...e/nvim/lazy/lspsaga.nvim/lua/lspsaga/diagnostic/init.lua:276>
```