### PR TITLE
Feature: respect `vim.diagnostic.config.severity_sort`

### DIFF
--- a/lua/lspsaga/diagnostic/show.lua
+++ b/lua/lspsaga/diagnostic/show.lua
@@ -36,6 +36,11 @@ end
 
 ---single linked list
 local function generate_list(entrys)
+  -- Sort diagnostics by severity (ascending: Error -> Warning -> Info -> Hint)
+  table.sort(entrys, function(a, b)
+    return a.severity < b.severity
+  end)
+
   local list = new_node()
 
   local curnode

--- a/lua/lspsaga/diagnostic/show.lua
+++ b/lua/lspsaga/diagnostic/show.lua
@@ -36,10 +36,16 @@ end
 
 ---single linked list
 local function generate_list(entrys)
-  -- Sort diagnostics by severity (ascending: Error -> Warning -> Info -> Hint)
-  table.sort(entrys, function(a, b)
-    return a.severity < b.severity
-  end)
+  -- Safely check if severity_sort is enabled
+  local diagnostic_config = vim.diagnostic.config and vim.diagnostic.config()
+  local severity_sort_enabled = diagnostic_config and diagnostic_config.severity_sort
+
+  if severity_sort_enabled then
+    -- Sort diagnostics by severity (ascending: Error -> Warning -> Info -> Hint)
+    table.sort(entrys, function(a, b)
+      return a.severity < b.severity
+    end)
+  end
 
   local list = new_node()
 

--- a/lua/lspsaga/diagnostic/show.lua
+++ b/lua/lspsaga/diagnostic/show.lua
@@ -41,8 +41,17 @@ local function generate_list(entrys)
   local severity_sort_enabled = diagnostic_config and diagnostic_config.severity_sort
 
   if severity_sort_enabled then
-    -- Sort diagnostics by severity (ascending: Error -> Warning -> Info -> Hint)
+    -- Sort diagnostics by severity, then by line number, then by column number
     table.sort(entrys, function(a, b)
+      if a.severity == b.severity then
+        if a.lnum == b.lnum then
+          -- Sort by column if severity and line are equal
+          return a.col < b.col
+        end
+        -- Sort by line number if severities are equal
+        return a.lnum < b.lnum
+      end
+      -- Otherwise, sort by severity (ascending: Error -> Warning -> Info -> Hint)
       return a.severity < b.severity
     end)
   end


### PR DESCRIPTION
Added a check if `vim.diagnostic.config.severity_sort` is enabled, if so, sort diagnostic msgs in asc severity order.