### PR TITLE
Nvim11 position encoding fix

### DIFF
--- a/lua/lspsaga/callhierarchy.lua
+++ b/lua/lspsaga/callhierarchy.lua
@@ -470,7 +470,7 @@ function ch:send_prepare_call()
   end
   self.list = slist.new()
 
-  local params = lsp.util.make_position_params(0, util.get_offset_encoding({ client = client}))
+  local params = lsp.util.make_position_params(0, util.get_offset_encoding({ client = client }))
   client.request(get_method(1), params, function(_, result, ctx)
     if api.nvim_get_current_buf() ~= ctx.bufnr then
       return

--- a/lua/lspsaga/callhierarchy.lua
+++ b/lua/lspsaga/callhierarchy.lua
@@ -469,7 +469,7 @@ function ch:send_prepare_call()
   end
   self.list = slist.new()
 
-  local params = lsp.util.make_position_params()
+  local params = lsp.util.make_position_params(0, util.get_offset_encoding({ client = client}))
   client.request(get_method(1), params, function(_, result, ctx)
     if api.nvim_get_current_buf() ~= ctx.bufnr then
       return

--- a/lua/lspsaga/codeaction/init.lua
+++ b/lua/lspsaga/codeaction/init.lua
@@ -173,17 +173,18 @@ function act:send_request(main_buf, options, callback)
     context.diagnostics = lsp.diagnostic.get_line_diagnostics(bufnr)
   end
   local params
+  local offset_encoding = util.get_offset_encoding({ bufnr = main_buf })
   local mode = api.nvim_get_mode().mode
   if options.range then
     assert(type(options.range) == 'table', 'code_action range must be a table')
     local start = assert(options.range.start, 'range must have a `start` property')
     local end_ = assert(options.range['end'], 'range must have a `end` property')
-    params = lsp.util.make_given_range_params(start, end_)
+    params = lsp.util.make_given_range_params(start, end_, main_buf, offset_encoding)
   elseif mode == 'v' or mode == 'V' then
     local range = range_from_selection(0, mode)
-    params = lsp.util.make_given_range_params(range.start, range['end'])
+    params = lsp.util.make_given_range_params(range.start, range['end'], main_buf, offset_encoding)
   else
-    params = lsp.util.make_range_params()
+    params = lsp.util.make_range_params(0, offset_encoding)
   end
 
   params.context = context

--- a/lua/lspsaga/codeaction/init.lua
+++ b/lua/lspsaga/codeaction/init.lua
@@ -177,7 +177,7 @@ function act:send_request(main_buf, options, callback)
     params = lsp.util.make_given_range_params(start, end_, nil, offset_encoding)
   elseif mode == 'v' or mode == 'V' then
     local range = range_from_selection(0, mode)
-    params = lsp.util.make_given_range_params(range.start, range['end'], main_buf, offset_encoding)
+    params = lsp.util.make_given_range_params(range.start, range['end'], nil, offset_encoding)
   else
     params = lsp.util.make_range_params(0, offset_encoding)
   end

--- a/lua/lspsaga/codeaction/lightbulb.lua
+++ b/lua/lspsaga/codeaction/lightbulb.lua
@@ -2,6 +2,7 @@ local api, lsp, fn = vim.api, vim.lsp, vim.fn
 ---@diagnostic disable-next-line: deprecated
 local uv = vim.version().minor >= 10 and vim.uv or vim.loop
 local config = require('lspsaga').config
+local util = require('lspsaga.util')
 local nvim_buf_set_extmark = api.nvim_buf_set_extmark
 local inrender_row = -1
 local inrender_buf = nil
@@ -54,7 +55,7 @@ end
 
 local function render(bufnr)
   local row = api.nvim_win_get_cursor(0)[1] - 1
-  local params = lsp.util.make_range_params()
+  local params = lsp.util.make_range_params(0, util.get_offset_encoding({ bufnr = bufnr }))
   params.context = {
     diagnostics = lsp.diagnostic.get_line_diagnostics(bufnr),
   }

--- a/lua/lspsaga/codeaction/lightbulb.lua
+++ b/lua/lspsaga/codeaction/lightbulb.lua
@@ -57,7 +57,7 @@ local function render(bufnr)
   local row = api.nvim_win_get_cursor(0)[1] - 1
   local params = lsp.util.make_range_params(0, util.get_offset_encoding({ bufnr = bufnr }))
   params.context = {
-    diagnostics = lsp.diagnostic.get_line_diagnostics(bufnr),
+    diagnostics = vim.diagnostic.get(bufnr),
   }
 
   lsp.buf_request(bufnr, 'textDocument/codeAction', params, function(_, result, _)

--- a/lua/lspsaga/codeaction/preview.lua
+++ b/lua/lspsaga/codeaction/preview.lua
@@ -112,11 +112,12 @@ local function create_preview_win(content, main_winid)
 
   local winheight = api.nvim_win_get_height(win_conf.win)
   local win_margin = config.ui.border == 'none' and 0 or 2
+  local preview_padding = 2
   if win_conf.anchor:find('^S') then
-    opt.row = util.is_ten and win_conf.row - 3 or win_conf.row[false] - win_conf.height - win_margin
+    opt.row = util.is_ten and win_conf.row - win_conf.height - preview_padding or win_conf.row[false] - win_conf.height - win_margin
     max_height = util.is_ten and win_conf.row or win_conf.row[false] - win_conf.height
   elseif win_conf.anchor:find('^N') then
-    opt.row = util.is_ten and win_conf.row + 3 or win_conf.row[false] + win_conf.height + win_margin
+    opt.row = util.is_ten and win_conf.row + win_conf.height + preview_padding or win_conf.row[false] + win_conf.height + win_margin
     max_height = winheight - opt.row
   end
 

--- a/lua/lspsaga/definition.lua
+++ b/lua/lspsaga/definition.lua
@@ -227,7 +227,7 @@ function def:definition_request(method, handler_T, args)
     fn.settagstack(api.nvim_get_current_win(), { items = items }, 't')
 
     local res
-    if not vim.tbl_islist(result) then
+    if not vim.islist(result) then
       res = result
     elseif result[1] then
       res = result[1]

--- a/lua/lspsaga/definition.lua
+++ b/lua/lspsaga/definition.lua
@@ -196,7 +196,7 @@ function def:definition_request(method, handler_T, args)
 
   local current_buf = api.nvim_get_current_buf()
 
-  local params = lsp.util.make_position_params()
+  local params = lsp.util.make_position_params(0, util.get_offset_encoding({ bufnr = current_buf }))
   if not self.opt_restore then
     self.opt_restore = win:minimal_restore()
   end

--- a/lua/lspsaga/finder/init.lua
+++ b/lua/lspsaga/finder/init.lua
@@ -503,7 +503,7 @@ function fd:new(args)
   end
 
   self.list = slist.new()
-  local params = lsp.util.make_position_params()
+  local params = lsp.util.make_position_params(0, util.get_offset_encoding({ bufnr = curbuf }))
   params.context = {
     includeDeclaration = true,
   }

--- a/lua/lspsaga/hover.lua
+++ b/lua/lspsaga/hover.lua
@@ -249,7 +249,7 @@ function hover:do_request(args)
       else
         value = result.contents.value
       end
-    elseif vim.tbl_islist(result.contents) then -- MarkedString[]
+    elseif vim.islist(result.contents) then -- MarkedString[]
       if vim.tbl_isempty(result.contents) and ignore_error(args) then
         vim.notify('No information available')
         return

--- a/lua/lspsaga/hover.lua
+++ b/lua/lspsaga/hover.lua
@@ -210,7 +210,6 @@ local function ignore_error(args, can_through)
 end
 
 function hover:do_request(args)
-  local params = lsp.util.make_position_params()
   local method = 'textDocument/hover'
   local clients = util.get_client_by_method(method)
   if #clients == 0 then
@@ -220,6 +219,7 @@ function hover:do_request(args)
   end
   local count = 0
 
+  local params = lsp.util.make_position_params(0, util.get_offset_encoding({ client = clients[1] }))
   lsp.buf_request(api.nvim_get_current_buf(), method, params, function(_, result, ctx)
     count = count + 1
     if count == #clients then

--- a/lua/lspsaga/rename/init.lua
+++ b/lua/lspsaga/rename/init.lua
@@ -47,13 +47,13 @@ end
 
 function rename:find_reference()
   local bufnr = api.nvim_get_current_buf()
-  local params = lsp.util.make_position_params()
-  params.context = { includeDeclaration = true }
   local clients = util.get_client_by_method('textDocument/references')
   if #clients == 0 then
     return
   end
 
+  local params = lsp.util.make_position_params(0, util.get_offset_encoding({ client = clients[1] }))
+  params.context = { includeDeclaration = true }
   clients[1].request('textDocument/references', params, function(_, result)
     if not result then
       return

--- a/lua/lspsaga/util.lua
+++ b/lua/lspsaga/util.lua
@@ -216,4 +216,44 @@ function M.sub_mac_c_header(fname)
   return fname:sub(pos + 1)
 end
 
+
+--- Key value pairs used to filter the approach
+--- Use client directly
+--- @class lspsaga.util.get_offset_encoding.Filter
+--- @inlinedoc
+--- @field client? table
+---
+--- Try to use the first client that matches bufnr
+--- @field bufnr? integer
+---
+--- Try to use the given method to retrieve the client
+--- @field method? string
+---
+---@param filter table
+---@param fallback string
+---@return string 'utf-8'|'utf-16'|'utf-32'
+function M.get_offset_encoding(filter, fallback)
+  vim.validate('filter', filter, 'table', true)
+  filter = filter or {}
+  fallback = fallback or 'utf-16'
+
+  if filter.client then
+    if filter.client and filter.client.offset_encoding then
+      return filter.client.offset_encoding
+    end
+  elseif filter.bufnr then
+    local clients = lsp.get_clients({ bufnr = filter.bufnr })
+    if #clients > 0 and clients[1].offset_encoding then
+      return clients[1].offset_encoding
+    end
+  elseif filter.method then
+    local clients = M.get_client_by_method(filter.method)[1].offset_encoding
+    if #clients > 0 and clients[1].offset_encoding then
+      return clients[1].offset_encoding
+    end
+  end
+
+  return fallback
+end
+
 return M


### PR DESCRIPTION
Make sure to always pass a offset_encoding to `make_given_range_params` and `make_position_params`. This is now a warning in nvim 11 even though the functionality hasnt changed, so it's backwards compatible.

Also slight refactorting, add util function `get_offset_encoding` with table for filtering how to get it to match new nvim api. This is used everywhere now.