### PR TITLE
Add option for jumping into the hover floating window on the first press.

### DIFF
--- a/lua/lspsaga/hover.lua
+++ b/lua/lspsaga/hover.lua
@@ -213,6 +213,10 @@ function hover:open_floating_preview(content, option_fn)
       pcall(util.delete_scroll_map, curbuf)
     end,
   })
+
+  if config.hover.jump_on_first_press then
+    api.nvim_set_current_win(self.winid)
+  end
 end
 
 local function ignore_error(args, can_through)

--- a/lua/lspsaga/init.lua
+++ b/lua/lspsaga/init.lua
@@ -23,6 +23,7 @@ local default_config = {
     max_height = 0.8,
     open_link = 'gx',
     open_cmd = '!chrome',
+    jump_on_first_press = false,
   },
   diagnostic = {
     show_layout = 'float',

--- a/lua/lspsaga/luadoc.lua
+++ b/lua/lspsaga/luadoc.lua
@@ -86,6 +86,7 @@
 ---@field max_height? number Defines float window height
 ---@field open_link? string Key for opening links
 ---@field open_cmd? string Cmd for opening links
+---@field jump_on_first_press? boolean Jump directly into the hover window on the first press instead of the default two presses.
 
 ---@class LspsagaConfig.Diagnostic
 ---@field show_layout? LayoutOption Config layout of diagnostic window not jump window


### PR DESCRIPTION
I get annoyed that it takes so many key presses to close the hover window. Either I have to move my cursor which I don't want to do most times, resulting in me just moving it back. Or, I have to press my keybind to jump into the window again and then q to close it.

This is an option which just moves the cursor directly into the window when you open it, this way you can close it using q directly. 

At first I thought about letting q close the window without jumping into it and let that be the option. However, then it can't use a buffer specific keybinding, I think this is the better choice. However, I'm open for suggestions, this at least fixes my issue.