### PR TITLE
Fix Deno path handling in definition module

### DIFF
--- a/lua/lspsaga/definition.lua
+++ b/lua/lspsaga/definition.lua
@@ -66,6 +66,14 @@ function def:close_all()
   api.nvim_del_augroup_by_name('SagaPeekdefinition')
 end
 
+local function transform_deno_path(fname)
+  if not fname:match('^deno:/') then
+    return fname
+  end
+  fname = fname:gsub('%%40', '@')
+  return fname:gsub('^deno:', 'deno\\:')
+end
+
 function def:apply_maps(bufnr)
   for action, map in pairs(config.definition.keys) do
     if action ~= 'close' then
@@ -86,6 +94,7 @@ function def:apply_maps(bufnr)
         self:close_all()
         local curbuf = api.nvim_get_current_buf()
         if action ~= 'edit' or curbuf ~= bufnr then
+          fname = transform_deno_path(fname)
           vim.cmd[action](fname)
         end
         restore()


### PR DESCRIPTION
When using definition in Deno, the following issue occurs:
https://github.com/neovim/neovim/issues/30908

Since it opens a non-existent path as a virtual file, executing the edit command from peek definition attempts to create and open an inappropriate path that includes the cwd, resulting in an error. I have added a process to convert the path appropriately when opening files that start with deno:/. " 