### PR TITLE
Support custom action functions

### DIFF
--- a/lua/lspsaga/finder/init.lua
+++ b/lua/lspsaga/finder/init.lua
@@ -438,16 +438,31 @@ function fd:apply_maps()
         if inexist and (action == 'split' or action == 'vsplit') then
           local reuse = box.win_reuse(action)
           if not reuse then
-            vim.cmd[action](fname)
+            if (config.finder.actions or {})[action] then
+              config.finder.actions[action](fname)
+            else
+              vim.cmd[action](fname)
+            end
           else
             api.nvim_win_set_buf(reuse, fn.bufadd(fname))
             api.nvim_set_current_win(reuse)
           end
         else
-          vim.cmd[action](fname)
+          if (config.finder.actions or {})[action] then
+            config.finder.actions[action](fname)
+          else
+            vim.cmd[action](fname)
+          end
         end
         restore()
-        api.nvim_win_set_cursor(0, pos)
+        xpcall(
+          function ()
+            api.nvim_win_set_cursor(0, pos)
+          end,
+          function (err)
+            print(err.message)
+          end
+        )
         beacon({ pos[1] - 1, 0 }, #api.nvim_get_current_line())
         return
       end

--- a/lua/lspsaga/init.lua
+++ b/lua/lspsaga/init.lua
@@ -96,6 +96,7 @@ local default_config = {
       quit = 'q',
       close = '<C-c>k',
     },
+    actions = {},
   },
   definition = {
     width = 0.6,


### PR DESCRIPTION
Problem:
There are use cases where you may wish to call a function instead of mapping a command directly to a key action for the finder UI.

Solution:
Supports configuring a `lspsaga.config.finder.actions` object mapping action names to callable functions.

```lua
require('lspsaga').setup({
  finder = {
    keys = {
      open = "<CR>",
    },
    actions = {
      open = function (fname)
        print("Selected filename", fname)
      end
    },
  }
})
```

Additionally, this wraps the final `api.nvim_win_set_cursor(0, pos)` call in `xpcall` given that this may fail if the function does not finish synchronously, like spawning a telescope interface.

Fixes #1523