### PR TITLE
Fix(diagnostics) not showing when severity_sort is disabled

### DIFF
--- a/lua/lspsaga/diagnostic/show.lua
+++ b/lua/lspsaga/diagnostic/show.lua
@@ -76,9 +76,11 @@ local function generate_list(entrys, callback)
         callback(list)
       end
     end, 0)
-    return nil
   else
-    return create_linked_list(entrys)
+    local list = create_linked_list(entrys)
+    if callback then
+      callback(list)
+    end
   end
 end
 


### PR DESCRIPTION
Problem:
Diagnostics were not being displayed when the severity_sort option was not enabled in vim.diagnostic.config(). This issue occurred because the generate_list function only called the callback when severity_sort was set to true, leaving the diagnostics unprocessed in the opposite case.

Solution:
The generate_list function has been modified to always call the callback with the generated list, regardless of whether severity_sort is enabled. This ensures that diagnostics are displayed correctly in all scenarios. Additionally, unnecessary return statements were removed since the caller does not use the return value, simplifying the code.
This fix provides a consistent user experience by ensuring diagnostics work as expected, whether sorting by severity is enabled or not.

Fixes #1520 

