### PR TITLE
removes hint bulb tip

### DIFF
--- a/lua/lspsaga/codeaction/lightbulb.lua
+++ b/lua/lspsaga/codeaction/lightbulb.lua
@@ -171,7 +171,7 @@ local function lb_autocmd()
         group = group,
         buffer = buf,
         callback = function(args)
-          update(args.buf)
+
         end,
       })
 


### PR DESCRIPTION
this was causing a weird issue where my gutter would rapidly disappear and reappear when moving my cursor, so I removed it since I don't have much use for it anyways.