### PR TITLE
Add finder option ref_opt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,12 +53,14 @@ jobs:
           version: nightly
 
       - name: luajit
-        uses: leafo/gh-actions-lua@v10
+        uses: leafo/gh-actions-lua@v11
         with:
           luaVersion: "luajit-2.1"
 
       - name: luarocks
-        uses: leafo/gh-actions-luarocks@v4
+        uses: leafo/gh-actions-luarocks@v5
+        with:
+          luarocksVersion: "3.12.2"
 
       - name: run test
         shell: bash

--- a/doc/lspsaga.nvim.txt
+++ b/doc/lspsaga.nvim.txt
@@ -1,5 +1,5 @@
 *lspsaga.nvim.txt*
-                                  For Nvim 0.8.0    Last change: 2026 April 21
+                                  For Nvim 0.8.0    Last change: 2026 April 22
 
 ==============================================================================
 Table of Contents                             *lspsaga.nvim-table-of-contents*

--- a/lua/lspsaga/init.lua
+++ b/lua/lspsaga/init.lua
@@ -86,6 +86,7 @@ local default_config = {
     ly_botright = false,
     number = vim.o.number,
     relativenumber = vim.o.relativenumber,
+    ref_opt = true,
     keys = {
       shuttle = '[w',
       toggle_or_open = 'o',

--- a/lua/lspsaga/util.lua
+++ b/lua/lspsaga/util.lua
@@ -94,6 +94,33 @@ function M.get_client_by_method(method)
   return supports
 end
 
+--- generate LSP RPC method `textDocument/references` parameters by configuration.
+---@param method string LSP RPC method name
+---@param params table parameters for LSP RPC method
+---@param config table|boolean configuration for config.finder.ref_opt
+---@return table
+function M.gen_param_by_config(method, params, config)
+  if type(config) == 'table' and method == 'textDocument/references' then
+    local bufnr = vim.api.nvim_get_current_buf()
+    local clients = lsp.get_clients({ bufnr = bufnr })
+
+    for _, client in ipairs(clients or {}) do
+      -- Replace characters dash('-') to underscore('_') for LSP client name,
+      -- which is useful for some LSP client like `rust-analyzer`.
+      local client_name = string.gsub(client.name, '-', '_')
+      local v = vim.tbl_get(config, client_name)
+      if v ~= nil then
+        params.context = {
+          includeDeclaration = v,
+        }
+        return { method, params }
+      end
+    end
+  end
+
+  return { method, params }
+end
+
 function M.feedkeys(key)
   local k = api.nvim_replace_termcodes(key, true, false, true)
   api.nvim_feedkeys(k, 'nx', false)


### PR DESCRIPTION
Hi, thank you for such amazing plugin. 

I noticed the command `lspsaga finder def+ref` will display the definition and the references, but the definition also include in the references section:

### bashls

<img width="273" height="133" alt="image" src="https://github.com/user-attachments/assets/d4bf36b8-27a6-4734-8695-1663931cea02" />

### rust-analyzer

<img width="209" height="125" alt="image" src="https://github.com/user-attachments/assets/ef6175b9-022a-47c1-ba7c-58c87d03b5a9" />

and I also see the issue #1336 , so I open this PR and add an option `finder.ref_opt` which indicated the parameters `includeDeclaration` for the LSP RCP method `textDocument/references`, the default value is `true` and also can be  a `table` which can setup value for each LSP client for example:

```lua
local saga = require("lspsaga")

saga.setup({
    finder = {
      ref_opt = {
        bashls = false,
        rust_analyzer = false,
        lua_ls = true,
      },
    },
})
```

### bashls

<img width="322" height="154" alt="image" src="https://github.com/user-attachments/assets/ea6c1feb-bfac-4444-865a-79800441c596" />

### rust-analyzer

<img width="215" height="131" alt="image" src="https://github.com/user-attachments/assets/00d27dd1-bd51-42af-bb49-ab46fb766b4c" />

### lua_ls

<img width="337" height="151" alt="image" src="https://github.com/user-attachments/assets/87cf4b51-c178-4116-851d-cb240ed188ff" />

Any feedback is appreciated.

