### PR TITLE
Migrate deprectated nvim method calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Generated files
+doc/tags

--- a/lua/lspsaga/callhierarchy.lua
+++ b/lua/lspsaga/callhierarchy.lua
@@ -361,7 +361,7 @@ end
 
 function ch:call_hierarchy(item, client, timer_close, curlnum)
   self.pending_request = true
-  client.request(self.method, { item = item }, function(_, res)
+  client:request(self.method, { item = item }, function(_, res)
     self.pending_request = false
     curlnum = curlnum or 0
     local inlevel = curlnum == 0 and 2 or fn.indent(curlnum)
@@ -471,7 +471,7 @@ function ch:send_prepare_call()
   self.list = slist.new()
 
   local params = lsp.util.make_position_params(0, util.get_offset_encoding({ client = client }))
-  client.request(get_method(1), params, function(_, result, ctx)
+  client:request(get_method(1), params, function(_, result, ctx)
     if api.nvim_get_current_buf() ~= ctx.bufnr then
       return
     end

--- a/lua/lspsaga/codeaction/init.lua
+++ b/lua/lspsaga/codeaction/init.lua
@@ -254,7 +254,7 @@ function act:support_resolve(client)
   if vim.version().minor >= 10 then
     local reg = client.dynamic_capabilities:get('textDocument/codeAction', { bufnr = ctx.bufnr })
     return vim.tbl_get(reg or {}, 'registerOptions', 'resolveProvider')
-      or client.supports_method('codeAction/resolve')
+      or client:supports_method('codeAction/resolve')
   end
   return vim.tbl_get(client.server_capabilities, 'codeActionProvider', 'resolveProvider')
 end

--- a/lua/lspsaga/codeaction/init.lua
+++ b/lua/lspsaga/codeaction/init.lua
@@ -244,7 +244,7 @@ local function apply_action(action, client, enriched_ctx)
         arguments = command.arguments,
         workDoneToken = command.workDoneToken,
       }
-      client.request('workspace/executeCommand', params, nil, enriched_ctx.bufnr)
+      client:request('workspace/executeCommand', params, nil, enriched_ctx.bufnr)
     end
   end
   clean_ctx()
@@ -263,12 +263,12 @@ function act:get_resolve_action(client, action, bufnr)
   if not self:support_resolve(client) then
     return
   end
-  return client.request_sync('codeAction/resolve', action, 1500, bufnr).result
+  return client:request_sync('codeAction/resolve', action, 1500, bufnr).result
 end
 
 function act:do_code_action(action, client, enriched_ctx)
   if not action.edit and client and self:support_resolve(client) then
-    client.request('codeAction/resolve', action, function(err, resolved_action)
+    client:request('codeAction/resolve', action, function(err, resolved_action)
       if err then
         vim.notify(err.code .. ': ' .. err.message, vim.log.levels.ERROR)
         return

--- a/lua/lspsaga/codeaction/lightbulb.lua
+++ b/lua/lspsaga/codeaction/lightbulb.lua
@@ -150,7 +150,7 @@ local function lb_autocmd()
       if not client then
         return
       end
-      if not client.supports_method('textDocument/codeAction') then
+      if not client:supports_method('textDocument/codeAction') then
         return
       end
       if vim.tbl_contains(config.lightbulb.ignore.clients, client.name) then

--- a/lua/lspsaga/implement/init.lua
+++ b/lua/lspsaga/implement/init.lua
@@ -37,7 +37,7 @@ local function try_render(client_id, bufnr, pos, data)
     return
   end
   ---@diagnostic disable-next-line: invisible
-  client.request('textDocument/implementation', params, function(err, result)
+  client:request('textDocument/implementation', params, function(err, result)
     if err or api.nvim_get_current_buf() ~= bufnr then
       return
     end

--- a/lua/lspsaga/rename/init.lua
+++ b/lua/lspsaga/rename/init.lua
@@ -54,7 +54,7 @@ function rename:find_reference()
 
   local params = lsp.util.make_position_params(0, util.get_offset_encoding({ client = clients[1] }))
   params.context = { includeDeclaration = true }
-  clients[1].request('textDocument/references', params, function(_, result)
+  clients[1]:request('textDocument/references', params, function(_, result)
     if not result then
       return
     end

--- a/lua/lspsaga/symbol/head.lua
+++ b/lua/lspsaga/symbol/head.lua
@@ -170,7 +170,7 @@ function symbol:register_module()
       end
 
       local client = lsp.get_client_by_id(args.data.client_id)
-      if not client or not client.supports_method('textDocument/documentSymbol') then
+      if not client or not client:supports_method('textDocument/documentSymbol') then
         return
       end
 
@@ -183,7 +183,7 @@ function symbol:register_module()
       end
       self:buf_watcher(args.buf, group)
 
-      if config.implement.enable and client.supports_method('textDocument/implementation') then
+      if config.implement.enable and client:supports_method('textDocument/implementation') then
         require('lspsaga.implement').start()
       end
     end,

--- a/lua/lspsaga/symbol/head.lua
+++ b/lua/lspsaga/symbol/head.lua
@@ -86,7 +86,7 @@ function symbol:do_request(buf, client_id)
     }
   end
 
-  client.request('textDocument/documentSymbol', params, function(err, result, ctx)
+  client:request('textDocument/documentSymbol', params, function(err, result, ctx)
     if not api.nvim_buf_is_loaded(ctx.bufnr) or not self[ctx.bufnr] then
       return
     end

--- a/lua/lspsaga/symbol/init.lua
+++ b/lua/lspsaga/symbol/init.lua
@@ -106,7 +106,7 @@ function symbol:do_request(buf, client_id)
 
   self[buf].pending_request = true
 
-  client.request('textDocument/documentSymbol', params, function(err, result, ctx)
+  client:request('textDocument/documentSymbol', params, function(err, result, ctx)
     if not api.nvim_buf_is_loaded(ctx.bufnr) or not self[ctx.bufnr] then
       return
     end

--- a/lua/lspsaga/symbol/init.lua
+++ b/lua/lspsaga/symbol/init.lua
@@ -190,7 +190,7 @@ function symbol:register_module()
       end
 
       local client = lsp.get_client_by_id(args.data.client_id)
-      if not client or not client.supports_method('textDocument/documentSymbol') then
+      if not client or not client:supports_method('textDocument/documentSymbol') then
         return
       end
       self:do_request(args.buf, args.data.client_id)
@@ -199,7 +199,7 @@ function symbol:register_module()
         require('lspsaga.symbol.winbar').init_winbar(args.buf)
       end
 
-      if config.implement.enable and client.supports_method('textDocument/implementation') then
+      if config.implement.enable and client:supports_method('textDocument/implementation') then
         require('lspsaga.implement').start()
       end
     end,

--- a/lua/lspsaga/typehierarchy.lua
+++ b/lua/lspsaga/typehierarchy.lua
@@ -361,7 +361,7 @@ end
 
 function ch:type_hierarchy(item, client, timer_close, curlnum)
   self.pending_request = true
-  client.request(self.method, { item = item }, function(_, res)
+  client:request(self.method, { item = item }, function(_, res)
     self.pending_request = false
     curlnum = curlnum or 0
     local inlevel = curlnum == 0 and 2 or fn.indent(curlnum)
@@ -472,7 +472,7 @@ function ch:send_prepare_type()
   self.list = slist.new()
 
   local params = lsp.util.make_position_params()
-  client.request(get_method(1), params, function(_, result, ctx)
+  client:request(get_method(1), params, function(_, result, ctx)
     if api.nvim_get_current_buf() ~= ctx.bufnr then
       return
     end

--- a/lua/lspsaga/util.lua
+++ b/lua/lspsaga/util.lua
@@ -66,7 +66,7 @@ function M.get_client_by_method(method)
   local supports = {}
 
   for _, client in ipairs(clients or {}) do
-    if client.supports_method(method) then
+    if client:supports_method(method) then
       supports[#supports + 1] = client
     end
   end


### PR DESCRIPTION
These old usages cause warnings for plugin users. I just migrated the usages that I received warnings for. There might be more.
https://neovim.io/doc/user/deprecated.html