### PR TITLE
fix(winbar): use column-precise containment checks

### DIFF
--- a/lua/lspsaga/symbol/winbar.lua
+++ b/lua/lspsaga/symbol/winbar.lua
@@ -55,31 +55,33 @@ local function path_in_bar(buf)
 end
 
 --@private
-local function binary_search(tbl, line)
+local function pos_before(line, col, pos)
+  return line < pos.line or (line == pos.line and col < pos.character)
+end
+
+--@private
+local function pos_after(line, col, pos)
+  return line > pos.line or (line == pos.line and col > pos.character)
+end
+
+--@private
+local function binary_search(tbl, line, col)
   local left = 1
   local right = #tbl
-  local mid = 0
 
-  while true do
-    mid = bit.rshift(left + right, 1)
-    if not tbl[mid] then
-      return
-    end
-
+  while left <= right do
+    local mid = bit.rshift(left + right, 1)
     local range = tbl[mid].range or tbl[mid].location.range
     if not range then
       return
     end
 
-    if line >= range.start.line and line <= range['end'].line then
-      return mid
-    elseif line < range.start.line then
+    if pos_before(line, col, range.start) then
       right = mid - 1
-    else
+    elseif pos_after(line, col, range['end']) then
       left = mid + 1
-    end
-    if left > right then
-      return
+    else
+      return mid
     end
   end
 end
@@ -119,8 +121,8 @@ local function insert_elements(buf, node, elements)
 end
 
 --@private
-local function find_in_node(buf, tbl, line, elements)
-  local mid = binary_search(tbl, line)
+local function find_in_node(buf, tbl, line, col, elements)
+  local mid = binary_search(tbl, line, col)
   if not mid then
     return
   end
@@ -130,7 +132,7 @@ local function find_in_node(buf, tbl, line, elements)
   insert_elements(buf, tbl[mid], elements)
 
   if node.children ~= nil and next(node.children) ~= nil then
-    find_in_node(buf, node.children, line, elements)
+    find_in_node(buf, node.children, line, col, elements)
   end
 end
 
@@ -147,12 +149,13 @@ local function render_symbol_winbar(buf, symbols)
     return
   end
 
-  local current_line = api.nvim_win_get_cursor(cur_win)[1]
+  local cursor = api.nvim_win_get_cursor(cur_win)
+  local current_line, current_col = cursor[1], cursor[2]
   local winbar_str = config.show_file and path_in_bar(buf) or ''
 
   local winbar_elements = {}
 
-  find_in_node(buf, symbols, current_line - 1, winbar_elements)
+  find_in_node(buf, symbols, current_line - 1, current_col, winbar_elements)
 
   local lens, over_idx = 0, 0
   local max_width = math.floor(api.nvim_win_get_width(cur_win) * 0.9)


### PR DESCRIPTION
### The Problem

When a document has multiple symbols on the same line, the winbar breadcrumb often lands on the wrong one, I ran into this while working on a custom LSP, but it's  easily repro-able with other more common tools. For example, jsonls:

```json
{ "alpha": 1, "beta": 2, "gamma": 3, "delta": 4, "epsilon": 5 }
```

<img width="705" height="60" alt="image" src="https://github.com/user-attachments/assets/7e22a22a-6741-4b8e-8bf5-09f1541d1494" />
<img width="702" height="58" alt="image" src="https://github.com/user-attachments/assets/632f1fd5-edde-46cc-b492-1e3cc8fa07b2" />
<img width="714" height="62" alt="image" src="https://github.com/user-attachments/assets/1012fa02-7419-4b0a-a9d6-ef9a804f67ee" />
<img width="705" height="64" alt="image" src="https://github.com/user-attachments/assets/6873babe-67e2-4f9c-943f-92900c674e81" />
<img width="709" height="62" alt="image" src="https://github.com/user-attachments/assets/835deb25-e556-42eb-916e-d689068ab535" />

(Note the final breadcrumb indicates `gamma` no matter where the cursor is placed.)

### The Solution

Make the `binary_search` function in `lua/lspsaga/symbol/winbar.lua` aware of columns.

Repro after:

<img width="710" height="69" alt="image" src="https://github.com/user-attachments/assets/e9b39cf3-e6b1-4cc0-b5b8-4073e2be55bb" />
<img width="710" height="68" alt="image" src="https://github.com/user-attachments/assets/183a4ab3-c976-483b-bc2b-9f0e6136a51b" />
<img width="700" height="61" alt="image" src="https://github.com/user-attachments/assets/f5b4948e-67ca-4e07-a6d6-e28b4aa3234c" />
<img width="704" height="63" alt="image" src="https://github.com/user-attachments/assets/0042272d-b9a3-4c0f-a34f-a69823d974de" />
<img width="704" height="62" alt="image" src="https://github.com/user-attachments/assets/13d896a3-7242-4b31-bf25-54deacc659f1" />

### Other considerations

#### Tests

I didn't add a test for this fix, as `winbar.lua` doesn't currently have any and `binary_search` is private. These all seemed like overkill, but if desired I could 
  - Add `winbar_spec.lua` and add test(s) there
  - Move `binary_search` to one of the util modules that already has tests, and add a test(s) there
  - Something else?

#### Encoding issues

I *think* `nvim_win_get_cursor` returns column in bytes, while LSP positions default to UTF-16 code units. This may lead to issues but I wasn't sure about the best way to address them.


Thanks for making and maintaining such a nice plugin!