### PR TITLE
fix(finder): defer BufEnter cleanup

### DIFF
--- a/lua/lspsaga/finder/init.lua
+++ b/lua/lspsaga/finder/init.lua
@@ -196,13 +196,21 @@ function fd:handler(method, results, spin_close, done)
     box.indent(ns, self.lbufnr, self.lwinid)
     api.nvim_create_autocmd('BufEnter', {
       callback = function(args)
-        if args.buf ~= self.lbufnr or args.buf ~= self.rbufnr then
-          self:clean()
-          api.nvim_del_autocmd(args.id)
-        end
+        self:close_on_bufenter(args)
       end,
     })
   end
+end
+
+function fd:close_on_bufenter(args)
+  if args.buf == self.lbufnr or args.buf == self.rbufnr then
+    return
+  end
+
+  api.nvim_del_autocmd(args.id)
+  vim.schedule(function()
+    self:clean()
+  end)
 end
 
 function fd:event()

--- a/test/finder_spec.lua
+++ b/test/finder_spec.lua
@@ -1,0 +1,57 @@
+require('lspsaga').setup({})
+
+local finder = require('lspsaga.finder')
+
+describe('finder module', function()
+  local lbufnr
+  local rbufnr
+  local autocmd
+
+  before_each(function()
+    lbufnr = vim.api.nvim_create_buf(false, true)
+    rbufnr = vim.api.nvim_create_buf(false, true)
+    finder.lbufnr = lbufnr
+    finder.rbufnr = rbufnr
+    finder.cleaned = false
+    finder.clean = function(self)
+      self.cleaned = true
+    end
+    autocmd = vim.api.nvim_create_autocmd('BufEnter', {
+      callback = function() end,
+    })
+  end)
+
+  after_each(function()
+    pcall(vim.api.nvim_del_autocmd, autocmd)
+    for _, bufnr in ipairs({ lbufnr, rbufnr }) do
+      if vim.api.nvim_buf_is_valid(bufnr) then
+        vim.api.nvim_buf_delete(bufnr, { force = true })
+      end
+    end
+    finder.lbufnr = nil
+    finder.rbufnr = nil
+    finder.cleaned = nil
+    finder.clean = nil
+  end)
+
+  it('keeps the finder open when entering finder buffers', function()
+    finder:close_on_bufenter({ buf = lbufnr, id = autocmd })
+
+    assert.is_false(finder.cleaned)
+    assert.is_equal(1, #vim.api.nvim_get_autocmds({ id = autocmd }))
+  end)
+
+  it('schedules cleanup after entering another buffer', function()
+    local other = vim.api.nvim_create_buf(false, true)
+
+    finder:close_on_bufenter({ buf = other, id = autocmd })
+
+    assert.is_equal(0, #vim.api.nvim_get_autocmds({ id = autocmd }))
+    vim.wait(100, function()
+      return finder.cleaned
+    end)
+    assert.is_true(finder.cleaned)
+
+    vim.api.nvim_buf_delete(other, { force = true })
+  end)
+end)


### PR DESCRIPTION
## Summary
- avoid treating finder buffers as external BufEnter targets
- defer finder cleanup out of the BufEnter autocmd before closing windows
- add finder tests for both in-finder and external buffer transitions

Closes #1560

## Test
- nix --extra-experimental-features 'nix-command flakes' shell nixpkgs#stylua -c stylua --check .
- nvim --headless + targeted close_on_bufenter assertions

Note: local vusted was unavailable in this environment; the Nix vusted package failed during wrapper generation before running tests.